### PR TITLE
feat: 添加第三方 Cookie 知识整理

### DIFF
--- a/.vitepress/config.mjs
+++ b/.vitepress/config.mjs
@@ -115,6 +115,7 @@ function createGuide() {
             { text: "Fetch", link: "/guide/03.agent/01.browser/02.fetch" },
             { text: "sendBeacon", link: "/guide/03.agent/01.browser/03.sendBeacon" },
             { text: "SSE", link: "/guide/03.agent/01.browser/04.sse" },
+            { text: "Worker", link: "/guide/03.agent/01.browser/05.worker" },
           ]
         },
         {

--- a/docs/cookie/third-party-cookie-overview.md
+++ b/docs/cookie/third-party-cookie-overview.md
@@ -1,0 +1,608 @@
+# 第三方 Cookie 详解
+
+> 第三方 Cookie 是 Web 隐私与安全领域中的核心话题。随着浏览器逐步淘汰第三方 Cookie，开发者需要深入理解其机制并做好迁移准备。
+
+## 目录
+
+- [基础概念](#基础概念)
+  - [什么是第三方 Cookie](#什么是第三方-cookie)
+  - [第一方 Cookie vs 第三方 Cookie](#第一方-cookie-vs-第三方-cookie)
+  - [Cookie 的基本工作机制](#cookie-的基本工作机制)
+- [核心用途](#核心用途)
+  - [跨域追踪](#跨域追踪)
+  - [广告定向](#广告定向)
+  - [会话共享](#会话共享)
+- [工作原理](#工作原理)
+  - [同源策略与 Cookie 共享](#同源策略与-cookie-共享)
+  - [第三方域名的 Cookie 是如何被写入的](#第三方域名的-cookie-是如何被写入的)
+  - [附带与非附带的 Cookie](#附带与非附带的-cookie)
+- [浏览器策略变化](#浏览器策略变化)
+  - [Chrome 淘汰时间线](#chrome-淘汰时间线)
+  - [Safari/Firefox 的 ITP/ETP 策略](#safarifirefox-的-itpetp-策略)
+  - [各浏览器支持现状](#各浏览器支持现状)
+- [替代方案](#替代方案)
+  - [First-party Sets](#first-party-sets)
+  - [Privacy Sandbox](#privacy-sandbox)
+  - [CHIPS](#chips)
+  - [Related Website Sets](#related-website-sets)
+  - [其他技术方案对比](#其他技术方案对比)
+- [开发者应对策略](#开发者应对策略)
+  - [如何检测第三方 Cookie 是否可用](#如何检测第三方-cookie-是否可用)
+  - [渐进式降级方案](#渐进式降级方案)
+  - [迁移到第一方 Cookie 的最佳实践](#迁移到第一方-cookie-的最佳实践)
+
+---
+
+## 基础概念
+
+### 什么是第三方 Cookie
+
+**第三方 Cookie（Third-party Cookie）** 是由当前页面域名以外的第三方域名设置的 Cookie。当用户访问 A 网站时，A 网站的页面嵌入了来自 B 域名的资源（如广告、脚本、图片），B 域名写入的 Cookie 即为第三方 Cookie。
+
+举例：用户访问 `tmall.com` 时，页面中包含来自 `mmstat.com` 或 `facebook.com` 等第三方域名的资源，这些第三方域名写入的 Cookie 就属于第三方 Cookie。
+
+### 第一方 Cookie vs 第三方 Cookie
+
+| 特性 | 第一方 Cookie | 第三方 Cookie |
+|------|--------------|----------------|
+| **设置域名** | 与用户当前访问的页面同域 | 与当前页面域名不同 |
+| **用途** | 维持会话、记住用户偏好 | 跨域追踪、广告定向 |
+| **访问权限** | 仅当前域名可读取 | 嵌入的第三方域名可读取 |
+| **隐私影响** | 较低，仅限同站 | 较高，可跨站追踪用户 |
+| **浏览器限制** | 基本不限制 | 逐步被禁用 |
+
+### Cookie 的基本工作机制
+
+Cookie 通过 HTTP 头在客户端与服务器之间传递：
+
+**服务器设置 Cookie（Set-Cookie 头）：**
+```
+Set-Cookie: name=value; Path=/; Domain=.example.com; Expires=Wed, 21 Oct 2026 07:28:00 GMT; Secure; HttpOnly; SameSite=Lax
+```
+
+**浏览器请求自动携带（Cookie 头）：**
+```
+Cookie: name=value; another=thing
+```
+
+**Cookie 的关键属性：**
+
+| 属性 | 作用 |
+|------|------|
+| `Domain` | 指定 Cookie 所属域名。不设置则仅限当前域名；设置父域名可实现跨子域名共享 |
+| `Path` | 指定 Cookie 的有效路径前缀，只有匹配该路径的请求才会携带 |
+| `Expires` | 绝对过期时间（GMT 格式） |
+| `Max-Age` | 相对过期时间（秒），优先级高于 Expires |
+| `Secure` | 仅在 HTTPS 连接下发送 |
+| `HttpOnly` | 无法通过 `document.cookie` 或 JavaScript 访问 |
+| `SameSite` | 控制跨站请求是否携带 Cookie（`Strict`/`Lax`/`None`） |
+
+---
+
+## 核心用途
+
+### 跨域追踪
+
+第三方 Cookie 最主要的用途是**跨站用户身份标识**。广告商和数据平台通过在大量网站嵌入自己的脚本，为用户生成唯一的追踪 ID，从而建立用户的行为档案。
+
+典型案例：**阿里妈妈 mmstat**
+
+当你访问百度、优酷、淘宝等阿里系网站时，`mmstat.com` 域下的 Cookie 会在多个站点共享，记录你的搜索、浏览、购买行为，用于构建精准的用户画像。
+
+```javascript
+// 第三方脚本写入 Cookie 的典型方式
+document.cookie = "uid=xxxxxx; Domain=.mmstat.com; Path=/";
+
+// 后续请求携带该 Cookie
+// GET /track?uid=xxxxxx&action=view HTTP/1.1
+// Cookie: uid=xxxxxx
+```
+
+### 广告定向
+
+广告平台（如 Facebook Pixel、Google Ads）通过第三方 Cookie 追踪用户在不同网站的行为，实现：
+
+- **受众构建**：根据浏览历史划分用户群体
+- **转化追踪**：追踪广告点击→访问→购买的完整转化链路
+- **频次控制**：避免同一用户看到同一广告过多次数
+- **重定向（Remarketing）**：用户访问 A 站点后，在 B 站点展示相关商品广告
+
+**Facebook Pixel 示例：**
+
+```javascript
+// 当用户访问商品页面时，触发 Pixel
+fbq('track', 'ViewContent', {
+  content_name: 'Premium Widget',
+  content_category: 'Electronics',
+  content_ids: ['widget_123']
+});
+```
+
+这会向 `facebook.com` 发送请求，携带第三方 Cookie 用于标识用户身份。
+
+### 会话共享
+
+同一企业的多个产品之间，通过第三方 Cookie 实现统一登录态。例如阿里巴巴的淘宝和天猫：
+
+- 登录信息统一存在第三方域名（如 `alibaba.com`）下
+- 淘宝、天猫各自嵌入该域名的登录脚本
+- 用户在任一平台登录后，访问另一平台无需重新登录
+
+> ⚠️ Safari 禁用第三方 Cookie 后，淘宝和天猫的免登录互通失效，用户需要分别登录。
+
+---
+
+## 工作原理
+
+### 同源策略与 Cookie 共享
+
+**同源策略（Same-Origin Policy）** 是浏览器最核心的安全机制之一，限制了一个源的文档或脚本如何与另一个源的资源交互。
+
+**源的判断：**
+```
+协议 + 域名 + 端口 三者完全相同 → 同源
+```
+
+**Cookie 的跨域共享规则：**
+
+| 场景 | Cookie 是否可共享 |
+|------|------------------|
+| 同域名下子域名（如 `a.example.com` → `b.example.com`） | ✅ 通过设置 `Domain=.example.com` |
+| 不同域名（如 `a.com` → `b.com`） | ❌ 浏览器同源策略禁止 |
+| 通过 `<iframe>` 嵌入跨域内容 | ❌ 受 Same-Origin Policy 限制 |
+
+**关键结论：Cookie 本身不支持真正的跨域共享。第三方 Cookie 的实现依赖于跨域资源的嵌入（图片、脚本、iframe），而非绕过同源策略。**
+
+### 第三方域名的 Cookie 是如何被写入的
+
+第三方 Cookie 通过以下方式被写入用户浏览器：
+
+**1. 图片/资源嵌入：**
+```html
+<!-- 1x1 透明像素，用于追踪 -->
+<img src="https://tracker.com/pixel.gif?uid=xxx" width="1" height="1">
+```
+
+**2. JavaScript 脚本嵌入：**
+```html
+<script src="https://analytics.com/analytics.js"></script>
+```
+```javascript
+// analytics.js 内容
+document.cookie = "visitor_id=abc123; Domain=.analytics.com; Path=/";
+```
+
+**3. iframe 嵌入（已逐渐失效）：**
+```html
+<iframe src="https://third-party.com/widget.html"></iframe>
+```
+
+**请求流程：**
+
+```
+用户访问 site.com
+    ↓
+site.com 返回 HTML（内含第三方资源引用）
+    ↓
+浏览器向 third-party.com 请求资源
+    ↓
+third-party.com 返回资源 + Set-Cookie 头
+    ↓
+浏览器存储第三方 Cookie
+    ↓
+后续访问任何嵌入 third-party.com 资源的站点时
+    ↓
+浏览器自动携带 third-party.com 的 Cookie
+```
+
+### 附带与非附带的 Cookie
+
+这是理解第三方 Cookie 工作机制的关键概念：
+
+**附带请求（Attributed Request）：**
+
+当用户访问 A 站点时，A 站点引导用户访问或触发对 B 域名的请求，该请求**附带**用户已有的 B 域名 Cookie。
+
+```
+用户先访问 facebook.com → facebook.com 设置 Cookie: fr=abc123
+用户再访问 myshop.com → myshop.com 页面内有 facebook.com 资源
+    → 浏览器请求 facebook.com 时自动携带 Cookie: fr=abc123
+    → facebook.com 通过 fr Cookie 识别这是同一用户
+```
+
+**非附带请求（Non-attributed Request）：**
+
+用户直接访问 B 域名（如在地址栏输入 `facebook.com`），或通过与 B 域名无关的途径访问，该请求**不附带**用户已有的 B Cookie（取决于 SameSite 设置）。
+
+**SameSite=Lax 的影响：**
+
+- `Strict`：所有跨站请求都不携带 Cookie
+- `Lax`：仅 GET 请求在跨站导航时携带 Cookie，POST 等危险方法不携带
+- `None`：所有请求都携带，但必须配合 `Secure` 使用
+
+---
+
+## 浏览器策略变化
+
+### Chrome 淘汰时间线
+
+| 时间 | 事件 |
+|------|------|
+| Chrome 51（2017） | 引入 `SameSite` 属性 |
+| Chrome 80（2020） | 默认 `SameSite=Lax`，强制要求 `SameSite=None` 必须 `Secure` |
+| Chrome 83（2020） | 隐私窗口模式禁用第三方 Cookie |
+| Chrome 94（2021） | 开始对 1% 用户隐藏第三方 Cookie |
+| Chrome 115（2023） | Privacy Sandbox API 正式上线 |
+| **2024-2025** | 第三方 Cookie 淘汰（分阶段推进） |
+| **2025** | 完全禁用第三方 Cookie（计划） |
+
+> ⚠️ 时间线因行业反馈多次推迟。2024 年 12 月 Google 宣布将淘汰时间推迟至 2025 年，并提供更多过渡工具。
+
+**SameSite 默认值变化：**
+
+```
+旧版（Chrome 79及之前）：
+  无 SameSite → 等同于 None（所有请求都携带）
+
+新版（Chrome 80+）：
+  无 SameSite → 等同于 Lax（仅导航GET请求携带）
+  SameSite=None → 必须配合 Secure=True
+```
+
+### Safari/Firefox 的 ITP/ETP 策略
+
+**Safari（Intelligent Tracking Prevention，ITP）：**
+
+| 版本 | 策略 |
+|------|------|
+| Safari 13.1+ | 默认完全阻止第三方 Cookie |
+| ITP 2.x | 使用 CNAME cloaking 绕过检测的追踪也被阻止 |
+| ITP 2.3+ | 第三方上下文中通过 JavaScript 设置的 Cookie 仅保留 7 天 |
+| ITP 2.4+ | 跨域资源通过 Link 标签设置 Cookie 的能力受限 |
+
+**Firefox（Enhanced Tracking Protection，ETP）：**
+
+| 版本 | 策略 |
+|------|------|
+| Firefox 79+ | 默认阻止第三方 Cookie（严格模式） |
+| ETP 2.0 | 允许例外（First-party Isolated Context） |
+
+**第三方 Cookie 屏蔽对主要平台的影响：**
+
+| 平台 | 影响 | 临时解决方案 |
+|------|------|-------------|
+| 淘宝/天猫 | 跨平台免登录失效 | 提示用户手动开启 |
+| 阿里妈妈广告 | 追踪能力下降 | 转向第一方数据 |
+| Google Ads | 部分功能受限 | Privacy Sandbox |
+
+### 各浏览器支持现状
+
+| 浏览器 | 第三方 Cookie 支持 | SameSite 默认值 |
+|--------|------------------|----------------|
+| Chrome 120+ | 逐步淘汰中 | `Lax` |
+| Safari 17+ | 完全阻止 | N/A |
+| Firefox 120+ | 完全阻止 | N/A |
+| Edge 120+ | 逐步淘汰 | `Lax` |
+| Opera 100+ | 逐步淘汰 | `Lax` |
+| Chrome（隐私浏览） | 完全阻止 | N/A |
+
+---
+
+## 替代方案
+
+### First-party Sets
+
+**First-party Sets（第一方集合）** 是 Google 提出的机制，允许同一实体下的多个域名在第三方 Cookie 语境下被视为"第一方"。
+
+**使用场景：**
+```json
+// Chrome 接受的 First-party Set 定义
+{
+  "owner": "example.com",
+  "members": ["sub1.example.com", "sub2.example.com"]
+}
+```
+
+设置后，`sub1.example.com` 和 `sub2.example.com` 在 `example.com` 的上下文中可以共享 Cookie，等同于第一方 Cookie。
+
+> ⚠️ 该方案因隐私监管压力被重新设计为 **Related Website Sets（RWS）**，大幅限制了可加入的域名数量。
+
+### Privacy Sandbox
+
+**Privacy Sandbox** 是 Google 主导的隐私保护技术栈，旨在提供广告追踪等功能的替代方案，同时保护用户隐私。
+
+**主要 API：**
+
+| API | 用途 |
+|-----|------|
+| **Topics API** | 根据用户浏览历史推断兴趣类别，供广告定向使用 |
+| **Protected Audience API** | 实现再营销（remarketing）功能，无需跨站追踪用户身份 |
+| **Attribution Reporting API** | 测量广告转化，支持聚合报告而非个体追踪 |
+| **Shared Storage API** | 提供跨站数据存储的通用机制 |
+
+**工作原理（Topics API 示例）：**
+```
+1. 浏览器根据用户访问历史推断兴趣主题（如"运动"、"电子产品"）
+2. 广告平台请求获取用户主题（浏览器侧完成，不暴露完整历史）
+3. 广告平台根据主题投放定向广告
+4. 无需追踪用户身份，用户隐私得到保护
+```
+
+### CHIPS
+
+**CHIPS（Cookies Having Independent Partitioned State）** 是基于 ** partitioned storage** 概念的 Cookie 机制。
+
+**解决的问题：**
+传统 Cookie 不区分上下文——同一个第三方 Cookie 在所有嵌入它的站点共享状态。CHIPS 通过分区机制，使 Cookie 按顶级站点独立。
+
+**工作原理：**
+```
+未使用 CHIPS：
+  用户访问 siteA.com → embed tracker.com 资源 → tracker.com 识别用户
+  用户访问 siteB.com → embed tracker.com 资源 → tracker.com 识别为同一用户 ✓
+
+使用 CHIPS：
+  用户访问 siteA.com → embed tracker.com 资源 → tracker.com 在 siteA.com 上下文中设置 Cookie
+  用户访问 siteB.com → embed tracker.com 资源 → tracker.com 在 siteB.com 上下文中设置独立的 Cookie
+  → tracker.com 无法跨站追踪用户 ✓
+```
+
+**Cookie 设置示例：**
+```http
+Set-Cookie: session_id=abc123; Path=/; SameSite=None; Secure; Partitioned
+```
+
+**适用场景：**
+- 嵌入式小组件（如聊天widget、评论系统）需要在每个站点独立维持会话
+- 不需要跨站追踪，只需在各自嵌入上下文中工作
+
+### Related Website Sets
+
+**Related Website Sets（RWS）** 是 First-party Sets 的精简版本，针对 Privacy Sandbox 过渡期设计。
+
+**主要限制：**
+- 每个 Set 最多包含 **3 个域名**（1 个主站 + 2 个关联站）
+- 必须证明域名之间有真实的技术或业务关联
+- 主要用于保持同企业多站点的核心功能（如 SSO）
+
+**申请要求：**
+- 站点必须归同一组织所有
+- 需提交技术验证和业务关联说明
+- 目前仅接受有限数量的申请
+
+### 其他技术方案对比
+
+| 方案 | 成熟度 | 隐私保护 | 跨站追踪能力 | 适用场景 |
+|------|--------|---------|------------|---------|
+| **第一方 Cookie** | ✅ 成熟 | 高 | ❌ 不可跨站 | 同域名下的用户识别 |
+| **CHIPS** | 🟡 部分支持 | 高 | ❌ 不可跨站 | 嵌入式 widget |
+| **RWS** | 🟡 有限支持 | 高 | ❌ 不可跨站 | 同企业多站点 SSO |
+| **Privacy Sandbox** | 🟡 推进中 | 高 | ⚠️ 受限 | 广告定向（过渡期） |
+| **浏览器指纹** | ✅ 成熟 | 低 | ⚠️ 可追踪 | 备选追踪手段 |
+| **帆布指纹 / WebGL** | ⚠️ 受限 | 低 | ⚠️ 可追踪 | 深度识别（被阻止中） |
+
+---
+
+## 开发者应对策略
+
+### 如何检测第三方 Cookie 是否可用
+
+**方法一：尝试写入并读取**
+```javascript
+function isThirdPartyCookieSupported() {
+  return new Promise((resolve) => {
+    const iframe = document.createElement('iframe');
+    iframe.src = 'https://example-third-party.com/cookie-check';
+    iframe.style.display = 'none';
+    
+    let timeoutId;
+    
+    iframe.onload = () => {
+      // 尝试通过 postMessage 与 iframe 通信
+      try {
+        iframe.contentWindow.postMessage('check', '*');
+      } catch (e) {
+        resolve(false);
+      }
+    };
+    
+    // 备用：超时则认为不支持
+    timeoutId = setTimeout(() => resolve(false), 2000);
+    
+    window.addEventListener('message', (event) => {
+      if (event.data === 'cookieSupported') {
+        clearTimeout(timeoutId);
+        resolve(true);
+      }
+    }, { once: true });
+    
+    document.body.appendChild(iframe);
+  });
+}
+```
+
+**方法二：使用 SameSite 行为检测**
+```javascript
+function detectCookieBehavior() {
+  // 创建测试 Cookie
+  const testCookieName = '__cookie_test_' + Date.now();
+  document.cookie = `${testCookieName}=1; Path=/`;
+  
+  const isFirstPartyCookieSupported = document.cookie.includes(testCookieName);
+  
+  // 清理
+  document.cookie = `${testCookieName}=; Max-Age=0; Path=/`;
+  
+  return {
+    firstPartyCookie: isFirstPartyCookieSupported,
+    thirdPartyCookie: !isFirstPartyCookieSupported // 简单判断
+  };
+}
+```
+
+**方法三：检测浏览器策略（推荐）**
+```javascript
+function getBrowserCookiePolicy() {
+  const ua = navigator.userAgent;
+  
+  if (ua.includes('Safari') && !ua.includes('Chrome')) {
+    return 'ITP'; // Safari - 完全阻止
+  }
+  if (ua.includes('Firefox')) {
+    return 'ETP'; // Firefox - 增强追踪保护
+  }
+  if (ua.includes('Edg/')) {
+    return 'Edge_Gradual'; // Edge - 逐步淘汰
+  }
+  if (ua.includes('Chrome/')) {
+    const version = parseInt(ua.match(/Chrome\/(\d+)/)?.[1] || '0');
+    if (version >= 115) return 'Chrome_Sandbox';
+    return 'Chrome_Lax'; // SameSite=Lax
+  }
+  return 'Unknown';
+}
+```
+
+### 渐进式降级方案
+
+**核心原则：功能降级，但不破坏核心用户体验**
+
+**阶段一：检测与警告（立即执行）**
+```javascript
+// 检测第三方 Cookie 不可用时记录日志
+if (!isThirdPartyCookieSupported()) {
+  console.warn('[CookieMigration] 第三方 Cookie 不可用，功能可能受限');
+  // 上报到监控系统
+  analytics.track('cookie_blocked', { type: 'third_party' });
+}
+```
+
+**阶段二：降级到第一方 Cookie**
+```javascript
+// 将第三方追踪 ID 迁移到第一方 Cookie
+function setFirstPartyIdentifier(userId) {
+  // 优先使用第一方 Cookie
+  const expiryDays = 365;
+  const expires = new Date();
+  expires.setTime(expires.getTime() + expiryDays * 24 * 60 * 60 * 1000);
+  
+  document.cookie = `__user_id=${userId}; Path=/; Expires=${expires.toUTCString()}; SameSite=Lax`;
+}
+
+// 在后续请求中携带
+function trackEvent(eventName, data) {
+  const userId = getFirstPartyIdentifier(); // 优先读取第一方 Cookie
+  sendBeacon('/api/track', {
+    event: eventName,
+    user: userId,
+    data: data,
+    timestamp: Date.now()
+  });
+}
+```
+
+**阶段三：使用 CHIPS 保持嵌入组件功能**
+```javascript
+// 对于嵌入式组件（聊天widget等），使用 CHIPS
+function setPartitionedCookie(name, value) {
+  const cookieStr = `${name}=${value}; Path=/; SameSite=None; Secure; Partitioned`;
+  document.cookie = cookieStr;
+}
+```
+
+### 迁移到第一方 Cookie 的最佳实践
+
+**1. 建立用户身份映射**
+
+不要依赖第三方平台分配的用户 ID，转而建立自己的用户身份体系：
+```javascript
+// 生成第一方用户 ID（UUID v4）
+function generateUserId() {
+  if (localStorage.getItem('user_id')) {
+    return localStorage.getItem('user_id');
+  }
+  const userId = crypto.randomUUID(); // 现代浏览器支持
+  localStorage.setItem('user_id', userId);
+  return userId;
+}
+```
+
+**2. 服务端存储用户状态**
+
+将用户状态从 Cookie 迁移到服务端 Session：
+```javascript
+// 登录时创建服务端 Session
+app.post('/login', (req, res) => {
+  const user = authenticate(req.body);
+  req.session.userId = user.id;
+  req.session.firstPartyToken = generateToken(); // 生成第一方 Token
+  res.json({ success: true });
+});
+
+// 后续请求通过 Session 识别用户
+app.get('/api/data', requireSession, (req, res) => {
+  const userId = req.session.userId;
+  res.json(getUserData(userId));
+});
+```
+
+**3. 使用 Privacy Sandbox API（当可用时）**
+
+```javascript
+// Topics API - 获取用户兴趣
+async function getUserInterests() {
+  if ('browsingTopics' in document) {
+    const topics = await document.browsingTopics();
+    return topics.map(t => t.topic);
+  }
+  return []; // 不支持时返回空
+}
+
+// Protected Audience API - 再营销
+async function runRemarketingAudience(audienceData) {
+  if ('runAdAuction' in navigator) {
+    const auctionConfig = {
+      seller: 'https://ad-network.example',
+      decisionLogicUrl: 'https://seller.example/decision-logic.js'
+    };
+    // 受保护的环境执行再营销
+  }
+}
+```
+
+**4. 数据层抽象**
+
+构建统一的数据抽象层，对上层屏蔽 Cookie 细节：
+```javascript
+const DataLayer = {
+  getUserId() {
+    return localStorage.getItem('user_id') || sessionStorage.getItem('session_id');
+  },
+  
+  setUserId(id) {
+    localStorage.setItem('user_id', id);
+  },
+  
+  track(event, data) {
+    // 自动选择可用方案
+    const payload = { event, userId: this.getUserId(), ...data };
+    if (navigator.sendBeacon) {
+      navigator.sendBeacon('/api/track', JSON.stringify(payload));
+    } else {
+      fetch('/api/track', { method: 'POST', body: JSON.stringify(payload), keepalive: true });
+    }
+  }
+};
+```
+
+---
+
+## 参考资料
+
+- [Google Privacy Sandbox](https://privacysandbox.com/)
+- [Chrome 第三方 Cookie 淘汰指南](https://developer.chrome.com/docs/privacy-sandbox/third-party-cookie-guide/)
+- [MDN - Cookie](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies)
+- [SameSite Cookie 规范](https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis)
+- [Chromium - CHIPS](https://developer.chrome.com/docs/privacy-sandbox/chips/)
+- [WebKit ITP](https://webkit.org/tracking-prevention/)
+

--- a/examples/browser-api/worker-memory/dedicated-worker/index.html
+++ b/examples/browser-api/worker-memory/dedicated-worker/index.html
@@ -1,0 +1,192 @@
+<!DOCTYPE html>
+<html lang="zh">
+  <head>
+    <meta charset="UTF-8" />
+    <title>DedicatedWorker 内存示例</title>
+    <style>
+      body {
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+        max-width: 900px;
+        margin: 0 auto;
+        padding: 20px;
+        background: #f5f5f5;
+      }
+      h1 { color: #333; border-bottom: 2px solid #4a90d9; padding-bottom: 10px; }
+      .card {
+        background: white;
+        border-radius: 8px;
+        padding: 20px;
+        margin: 15px 0;
+        box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+      }
+      .card h3 { margin-top: 0; color: #4a90d9; }
+      button {
+        background: #4a90d9;
+        color: white;
+        border: none;
+        padding: 10px 20px;
+        border-radius: 4px;
+        cursor: pointer;
+        margin: 5px;
+        font-size: 14px;
+      }
+      button:hover { background: #357abd; }
+      button:disabled { background: #ccc; cursor: not-allowed; }
+      .result {
+        background: #f8f8f8;
+        border-left: 4px solid #4a90d9;
+        padding: 12px;
+        margin-top: 10px;
+        font-family: 'Courier New', monospace;
+        font-size: 13px;
+        white-space: pre-wrap;
+        max-height: 200px;
+        overflow-y: auto;
+      }
+      .info {
+        background: #e8f4fd;
+        border-left: 4px solid #2196F3;
+        padding: 10px;
+        margin: 10px 0;
+        font-size: 13px;
+      }
+      .warning {
+        background: #fff3e0;
+        border-left: 4px solid #ff9800;
+        padding: 10px;
+        margin: 10px 0;
+        font-size: 13px;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>🔧 DedicatedWorker 内存示例</h1>
+
+    <div class="info">
+      <strong>原理：</strong>Worker 运行在渲染进程内，但有独立 V8 堆内存。
+      主线程和 Worker 共享进程地址空间，但不共享 JavaScript 对象。
+    </div>
+
+    <div class="card">
+      <h3>1. 斐波那契计算（不阻塞主线程）</h3>
+      <p>主线程计算大数值斐波那契会阻塞 UI，Worker 不会。</p>
+      <button onclick="testFibonacci(35)">计算 fib(35)</button>
+      <button onclick="testFibonacci(45)">计算 fib(45)</button>
+      <button onclick="testFibonacci(100)">计算 fib(100)</button>
+      <div id="fibResult" class="result">点击按钮开始计算...</div>
+    </div>
+
+    <div class="card">
+      <h3>2. 计算密集型任务</h3>
+      <p>模拟复杂计算，观察 Worker 如何处理。</p>
+      <button onclick="testHeavyCompute(10000000)">1千万次计算</button>
+      <button onclick="testHeavyCompute(50000000)">5千万次计算</button>
+      <button onclick="testHeavyCompute(100000000)">1亿次计算</button>
+      <div id="computeResult" class="result">点击按钮开始计算...</div>
+    </div>
+
+    <div class="card">
+      <h3>3. Worker 内存分配测试</h3>
+      <p>验证 Worker 有独立内存空间（注意：这里分配的数组不会影响主线程）</p>
+      <button onclick="testWorkerMemory(1000000)">分配 100万元素 (~8MB)</button>
+      <button onclick="testWorkerMemory(5000000)">分配 500万元素 (~40MB)</button>
+      <button onclick="testWorkerMemory(10000000)">分配 1000万元素 (~80MB)</button>
+      <div id="memoryResult" class="result">点击按钮观察 Worker 内存分配...</div>
+    </div>
+
+    <div class="warning">
+      <strong>注意：</strong>Worker 的内存来自渲染进程的 V8 堆，但与主线程独立。
+      多个 DedicatedWorker 会各自占用独立的 V8 堆空间。
+    </div>
+
+    <div class="card">
+      <h3>Worker 生命周期</h3>
+      <button onclick="createAndTerminateWorker()">创建 Worker，用完后终止</button>
+      <div id="lifecycleResult" class="result">点击按钮测试 Worker 生命周期...</div>
+    </div>
+
+    <script src="worker.js"></script>
+    <script>
+      let worker = null;
+      let workerCreated = false;
+
+      function getWorker() {
+        if (!worker) {
+          worker = new Worker('worker.js');
+          worker.onmessage = handleWorkerMessage;
+          worker.onerror = (e) => {
+            console.error('Worker error:', e);
+            appendResult('fibResult', 'Worker 错误: ' + e.message);
+          };
+          workerCreated = true;
+          appendResult('fibResult', '✅ Worker 已创建');
+        }
+        return worker;
+      }
+
+      function handleWorkerMessage(e) {
+        const { type, ...data } = e.data;
+        switch (type) {
+          case 'fibonacci-result':
+            appendResult('fibResult', `fib(${data.input}) = ${data.result}`);
+            break;
+          case 'heavy-result':
+            appendResult('computeResult', `完成 ${data.iterations.toLocaleString()} 次计算\n耗时: ${data.duration}ms\n结果: ${data.sum.toExponential(4)}`);
+            break;
+          case 'memory-result':
+            appendResult('memoryResult', `Worker 分配数组长度: ${data.arrayLength.toLocaleString()}\n估算内存: ${data.allocated.toFixed(2)} MB\n\n（主线程无法直接看到这部分内存，需要通过消息传递）`);
+            break;
+          case 'error':
+            console.error('Worker error:', data.message);
+            break;
+          case 'lifecycle':
+            appendResult('lifecycleResult', `Worker ${data.action}\n耗时: ${data.duration}ms`);
+            break;
+        }
+      }
+
+      function appendResult(elementId, text) {
+        const el = document.getElementById(elementId);
+        el.textContent = text;
+      }
+
+      function testFibonacci(n) {
+        const w = getWorker();
+        w.postMessage({ type: 'fibonacci', data: { n } });
+        appendResult('fibResult', `正在计算 fib(${n})...`);
+      }
+
+      function testHeavyCompute(iterations) {
+        const w = getWorker();
+        w.postMessage({ type: 'heavy-compute', data: { iterations } });
+        appendResult('computeResult', `正在计算 ${iterations.toLocaleString()} 次...`);
+      }
+
+      function testWorkerMemory(size) {
+        const w = getWorker();
+        w.postMessage({ type: 'memory-test', data: { size } });
+        appendResult('memoryResult', `正在 Worker 中分配 ${size.toLocaleString()} 元素...`);
+      }
+
+      function createAndTerminateWorker() {
+        const w = new Worker('worker.js');
+        w.onmessage = (e) => {
+          if (e.data.type === 'lifecycle') {
+            appendResult('lifecycleResult', `Worker ${e.data.action}\n耗时: ${e.data.duration}ms`);
+          }
+        };
+
+        const start = Date.now();
+        w.postMessage({ type: 'fibonacci', data: { n: 30 } });
+
+        // 模拟用完后终止
+        w.postMessage({ type: 'heavy-compute', data: { iterations: 1000000 } });
+        setTimeout(() => {
+          w.terminate();
+          const duration = Date.now() - start;
+          appendResult('lifecycleResult', `Worker 已终止\n从创建到终止耗时: ${duration}ms\n\nterminate() 会立即终止 Worker，释放其 V8 堆内存`);
+        }, 500);
+      }
+    </script>
+  </body>
+</html>

--- a/examples/browser-api/worker-memory/dedicated-worker/worker.js
+++ b/examples/browser-api/worker-memory/dedicated-worker/worker.js
@@ -1,0 +1,54 @@
+// DedicatedWorker - 计算密集型任务示例
+// Worker 线程：计算斐波那契数列（演示 Worker 内存独立）
+
+self.onmessage = function(e) {
+  const { type, data } = e.data;
+
+  switch (type) {
+    case 'fibonacci':
+      const result = fibonacci(data.n);
+      self.postMessage({ type: 'fibonacci-result', result, input: data.n });
+      break;
+    case 'heavy-compute':
+      // 模拟计算密集任务
+      const start = Date.now();
+      let sum = 0;
+      for (let i = 0; i < data.iterations; i++) {
+        sum += Math.sqrt(i) * Math.sin(i);
+      }
+      const duration = Date.now() - start;
+      self.postMessage({
+        type: 'heavy-result',
+        sum,
+        duration,
+        iterations: data.iterations
+      });
+      break;
+    case 'memory-test':
+      // 分配内存（演示 Worker 独立内存空间）
+      const arr = new Array(data.size);
+      for (let i = 0; i < data.size; i++) {
+        arr[i] = Math.random();
+      }
+      const usedMemory = arr.length * 8 / (1024 * 1024); // 假设每个数 8 字节
+      self.postMessage({
+        type: 'memory-result',
+        allocated: usedMemory,
+        arrayLength: arr.length
+      });
+      break;
+    default:
+      self.postMessage({ type: 'error', message: 'Unknown message type' });
+  }
+};
+
+function fibonacci(n) {
+  if (n <= 1) return n;
+  let a = 0, b = 1;
+  for (let i = 2; i <= n; i++) {
+    const temp = a + b;
+    a = b;
+    b = temp;
+  }
+  return b;
+}

--- a/examples/browser-api/worker-memory/shared-memory/index.html
+++ b/examples/browser-api/worker-memory/shared-memory/index.html
@@ -1,0 +1,265 @@
+<!DOCTYPE html>
+<html lang="zh">
+  <head>
+    <meta charset="UTF-8" />
+    <title>SharedArrayBuffer 共享内存示例</title>
+    <style>
+      body {
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+        max-width: 900px;
+        margin: 0 auto;
+        padding: 20px;
+        background: #f5f5f5;
+      }
+      h1 { color: #333; border-bottom: 2px solid #9c27b0; padding-bottom: 10px; }
+      .card {
+        background: white;
+        border-radius: 8px;
+        padding: 20px;
+        margin: 15px 0;
+        box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+      }
+      .card h3 { margin-top: 0; color: #9c27b0; }
+      button {
+        background: #9c27b0;
+        color: white;
+        border: none;
+        padding: 10px 20px;
+        border-radius: 4px;
+        cursor: pointer;
+        margin: 5px;
+        font-size: 14px;
+      }
+      button:hover { background: #7b1fa2; }
+      button:disabled { background: #ccc; cursor: not-allowed; }
+      .result {
+        background: #f8f8f8;
+        border-left: 4px solid #9c27b0;
+        padding: 12px;
+        margin-top: 10px;
+        font-family: 'Courier New', monospace;
+        font-size: 13px;
+        white-space: pre-wrap;
+        min-height: 60px;
+      }
+      .info {
+        background: #f3e5f5;
+        border-left: 4px solid #9c27b0;
+        padding: 10px;
+        margin: 10px 0;
+        font-size: 13px;
+      }
+      .warning {
+        background: #fff3e0;
+        border-left: 4px solid #ff9800;
+        padding: 10px;
+        margin: 10px 0;
+        font-size: 13px;
+      }
+      .success {
+        background: #e8f5e9;
+        border-left: 4px solid #4caf50;
+        padding: 10px;
+        margin: 10px 0;
+        font-size: 13px;
+      }
+      .array-display {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 4px;
+        margin-top: 10px;
+      }
+      .array-cell {
+        width: 40px;
+        height: 30px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: #9c27b0;
+        color: white;
+        border-radius: 4px;
+        font-size: 12px;
+        font-family: monospace;
+      }
+      .array-cell.active {
+        background: #4caf50;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>🔗 SharedArrayBuffer 共享内存示例</h1>
+
+    <div class="info">
+      <strong>原理：</strong>SharedArrayBuffer 允许多个线程共享同一块内存，<strong>无需拷贝</strong>。
+      使用 Atomics API 保证原子性操作，避免竞态条件。
+    </div>
+
+    <div class="warning">
+      <strong>⚠️ 安全要求：</strong>SharedArrayBuffer 需要 <code>Cross-Origin-Isolation</code>。
+      访问此页面需要服务器设置以下响应头：
+      <br><code>Cross-Origin-Embedder-Policy: require-corp</code>
+      <br><code>Cross-Origin-Opener-Policy: same-origin</code>
+      <br><br>
+      使用 Node.js 运行：<code>node server.js</code>，然后访问 <code>https://localhost:8443</code>
+    </div>
+
+    <div class="card">
+      <h3>1. 初始化共享内存</h3>
+      <button onclick="initSharedMemory()">初始化 SharedArrayBuffer (100个元素)</button>
+      <div id="initResult" class="result">点击按钮初始化共享内存...</div>
+    </div>
+
+    <div class="card">
+      <h3>2. 主线程写入，Worker 读取</h3>
+      <div style="margin: 10px 0;">
+        <input type="number" id="writeIndex" value="0" min="0" max="99" style="width:80px;padding:5px;" />
+        <input type="number" id="writeValue" value="100" style="width:80px;padding:5px;" />
+        <button onclick="writeToShared()" id="writeBtn" disabled>主线程写入</button>
+        <button onclick="workerRead()" id="readBtn" disabled>Worker 读取</button>
+      </div>
+      <div id="writeResult" class="result">等待初始化...</div>
+    </div>
+
+    <div class="card">
+      <h3>3. 原子递增测试</h3>
+      <p>多个 Worker 同时对同一位置原子递增，验证 Atomics 安全性</p>
+      <button onclick="atomicIncrement()" id="atomicBtn" disabled>Worker 原子递增 10 次</button>
+      <div id="atomicResult" class="result">等待初始化...</div>
+      <div id="arrayDisplay" class="array-display">等待初始化...</div>
+    </div>
+
+    <div class="card">
+      <h3>4. 内存对比</h3>
+      <button onclick="compareMemory()">对比 Transferable vs SharedArrayBuffer</button>
+      <div id="compareResult" class="result">点击按钮对比...</div>
+    </div>
+
+    <script>
+      let sharedBuffer = null;
+      let sharedArray = null;
+      let worker = null;
+
+      function checkSharedArrayBufferSupport() {
+        if (!window.SharedArrayBuffer) {
+          document.body.innerHTML = `
+            <h2 style="color:red;">❌ 您的浏览器不支持 SharedArrayBuffer</h2>
+            <p>SharedArrayBuffer 需要 Cross-Origin-Isolation。请通过 server.js 启动服务器访问。</p>
+          `;
+          return false;
+        }
+        return true;
+      }
+
+      checkSharedArrayBufferSupport();
+
+      function initSharedMemory() {
+        // 创建 SharedArrayBuffer
+        sharedBuffer = new SharedArrayBuffer(100 * 4); // 100 个 Int32 (4 bytes each)
+        sharedArray = new Int32Array(sharedBuffer);
+
+        // 初始化为 0
+        for (let i = 0; i < 100; i++) {
+          sharedArray[i] = 0;
+        }
+
+        // 发送给 Worker
+        worker = new Worker('worker.js');
+        worker.onmessage = function(e) {
+          const { type, ...data } = e.data;
+          if (type === 'init-done') {
+            document.getElementById('initResult').textContent =
+              `✅ 共享内存初始化成功！\nBuffer 大小: ${data.byteLength} bytes\n数组长度: ${data.arrayLength}`;
+            document.getElementById('writeBtn').disabled = false;
+            document.getElementById('readBtn').disabled = false;
+            document.getElementById('atomicBtn').disabled = false;
+            updateArrayDisplay();
+          }
+          if (type === 'incremented') {
+            document.getElementById('atomicResult').textContent =
+              `✅ Worker 递增完成！\n索引 ${data.index}: ${data.oldValue} → ${data.newValue}`;
+            updateArrayDisplay();
+          }
+          if (type === 'read-result') {
+            document.getElementById('writeResult').textContent =
+              `Worker 读取前 10 个值:\n[${data.values.join(', ')}]`;
+          }
+        };
+
+        // 传递 SharedArrayBuffer（无需拷贝，共享引用）
+        worker.postMessage({ type: 'init-shared', buffer: sharedBuffer }, [sharedBuffer]);
+
+        // ⚠️ 注意：sharedBuffer 在 postMessage 后仍可使用，因为是共享的
+        document.getElementById('initResult').textContent = '正在初始化共享内存...';
+      }
+
+      function writeToShared() {
+        if (!sharedArray) return;
+        const index = parseInt(document.getElementById('writeIndex').value);
+        const value = parseInt(document.getElementById('writeValue').value);
+        if (index >= 0 && index < 100) {
+          sharedArray[index] = value;
+          updateArrayDisplay();
+          document.getElementById('writeResult').textContent =
+            `主线程写入: sharedArray[${index}] = ${value}`;
+        }
+      }
+
+      function workerRead() {
+        if (!worker) return;
+        worker.postMessage({ type: 'read' });
+      }
+
+      async function atomicIncrement() {
+        if (!worker) return;
+        const index = parseInt(document.getElementById('writeIndex').value) || 0;
+        document.getElementById('atomicResult').textContent = '正在执行 10 次原子递增...';
+
+        for (let i = 0; i < 10; i++) {
+          worker.postMessage({ type: 'increment', index });
+          await new Promise(r => setTimeout(r, 100));
+        }
+      }
+
+      function updateArrayDisplay() {
+        if (!sharedArray) return;
+        const container = document.getElementById('arrayDisplay');
+        const count = Math.min(20, sharedArray.length);
+        let html = '';
+        for (let i = 0; i < count; i++) {
+          const val = sharedArray[i];
+          const active = val > 0 ? ' active' : '';
+          html += `<div class="array-cell${active}">[${i}]=${val}</div>`;
+        }
+        container.innerHTML = html;
+      }
+
+      async function compareMemory() {
+        const result = document.getElementById('compareResult');
+        result.textContent = '开始对比测试...\n';
+
+        // Test 1: Transferable (ArrayBuffer 转移)
+        const transferableBuffer = new ArrayBuffer(50 * 1024 * 1024); // 50MB
+        const transferWorker = new Worker('worker.js');
+        const t1 = performance.memory ? performance.memory.usedJSHeapSize : 0;
+        transferWorker.postMessage({ type: 'transfer-buffer', buffer: transferableBuffer }, [transferableBuffer]);
+        await new Promise(r => setTimeout(r, 200));
+        const t2 = performance.memory ? performance.memory.usedJSHeapSize : 0;
+        transferWorker.terminate();
+
+        result.textContent = `测试完成（需要 Chrome DevTools Memory 面板验证精确值）\n\n` +
+          `Transferable ArrayBuffer:\n` +
+          `  - 传递时无拷贝\n` +
+          `  - 主线程原 buffer 被清空 (byteLength=0)\n` +
+          `  - 适合一次性大数据传递\n\n` +
+          `SharedArrayBuffer:\n` +
+          `  - 主线程和 Worker 共享同一块内存\n` +
+          `  - 无需 postMessage 拷贝\n` +
+          `  - 适合频繁读写的场景\n` +
+          `  - 需要 Atomics 保证原子性\n\n` +
+          `推荐：\n` +
+          `  - 大数据一次性传递 → Transferable\n` +
+          `  - 频繁数据交换 → SharedArrayBuffer`;
+      }
+    </script>
+  </body>
+</html>

--- a/examples/browser-api/worker-memory/shared-memory/server.js
+++ b/examples/browser-api/worker-memory/shared-memory/server.js
@@ -1,0 +1,59 @@
+// SharedArrayBuffer 需要 Cross-Origin-Isolation
+// 运行此服务器：node server.js
+// 然后访问：https://localhost:8443
+
+import https from 'https';
+import http from 'http';
+import fs from 'fs';
+import path from 'path';
+
+const PORT = 8443;
+const options = {
+  key: fs.readFileSync(path.join(__dirname, '../fetch/upload/privkey.pem')),
+  cert: fs.readFileSync(path.join(__dirname, '../fetch/upload/fullchain.pem')),
+};
+
+const mimeTypes = {
+  '.html': 'text/html',
+  '.js': 'application/javascript',
+  '.css': 'text/css',
+  '.json': 'application/json',
+};
+
+const server = https.createServer(options, (req, res) => {
+  // 设置 COEP 和 COOP 头以启用 Cross-Origin-Isolation
+  res.setHeader('Cross-Origin-Embedder-Policy', 'require-corp');
+  res.setHeader('Cross-Origin-Opener-Policy', 'same-origin');
+  res.setHeader('Cross-Origin-Resource-Policy', 'cross-origin');
+
+  let filePath = '.' + req.url;
+  if (filePath === './') {
+    filePath = './index.html';
+  }
+
+  const extname = String(path.extname(filePath)).toLowerCase();
+  const contentType = mimeTypes[extname] || 'application/octet-stream';
+
+  fs.readFile(filePath, (error, content) => {
+    if (error) {
+      if (error.code === 'ENOENT') {
+        res.writeHead(404);
+        res.end('File not found');
+      } else {
+        res.writeHead(500);
+        res.end('Server error: ' + error.code);
+      }
+    } else {
+      res.writeHead(200, { 'Content-Type': contentType });
+      res.end(content, 'utf-8');
+    }
+  });
+});
+
+server.listen(PORT, () => {
+  console.log(`🚀 SharedArrayBuffer Server running at https://localhost:${PORT}/`);
+  console.log(`📋 Required headers set:`);
+  console.log(`   Cross-Origin-Embedder-Policy: require-corp`);
+  console.log(`   Cross-Origin-Opener-Policy: same-origin`);
+  console.log(`\n⚠️  Note: Self-signed certificates - accept the warning in your browser`);
+});

--- a/examples/browser-api/worker-memory/shared-memory/worker.js
+++ b/examples/browser-api/worker-memory/shared-memory/worker.js
@@ -1,0 +1,43 @@
+// SharedArrayBuffer - 共享内存示例
+// Worker 线程：与主线程共享同一块内存，无需拷贝
+
+let sharedBuffer = null;
+let sharedArray = null;
+
+self.onmessage = function(e) {
+  const { type, buffer } = e.data;
+
+  if (type === 'init-shared') {
+    // 接收 SharedArrayBuffer（无需拷贝）
+    sharedBuffer = buffer;
+    sharedArray = new Int32Array(buffer);
+
+    self.postMessage({
+      type: 'init-done',
+      byteLength: buffer.byteLength,
+      arrayLength: sharedArray.length
+    });
+  }
+
+  if (type === 'increment') {
+    // 使用 Atomics 保证原子性递增
+    const index = e.data.index;
+    const oldValue = Atomics.add(sharedArray, index, 1);
+    const newValue = Atomics.load(sharedArray, index);
+
+    self.postMessage({
+      type: 'incremented',
+      index,
+      oldValue,
+      newValue
+    });
+  }
+
+  if (type === 'read') {
+    const values = [];
+    for (let i = 0; i < Math.min(10, sharedArray.length); i++) {
+      values.push(Atomics.load(sharedArray, i));
+    }
+    self.postMessage({ type: 'read-result', values });
+  }
+};

--- a/examples/browser-api/worker-memory/transferable/index.html
+++ b/examples/browser-api/worker-memory/transferable/index.html
@@ -1,0 +1,247 @@
+<!DOCTYPE html>
+<html lang="zh">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Transferable vs postMessage 内存拷贝对比</title>
+    <style>
+      body {
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+        max-width: 900px;
+        margin: 0 auto;
+        padding: 20px;
+        background: #f5f5f5;
+      }
+      h1 { color: #333; border-bottom: 2px solid #4caf50; padding-bottom: 10px; }
+      .card {
+        background: white;
+        border-radius: 8px;
+        padding: 20px;
+        margin: 15px 0;
+        box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+      }
+      .card h3 { margin-top: 0; color: #4caf50; }
+      button {
+        background: #4caf50;
+        color: white;
+        border: none;
+        padding: 10px 20px;
+        border-radius: 4px;
+        cursor: pointer;
+        margin: 5px;
+        font-size: 14px;
+      }
+      button:hover { background: #43a047; }
+      button:disabled { background: #ccc; cursor: not-allowed; }
+      .result {
+        background: #f8f8f8;
+        border-left: 4px solid #4caf50;
+        padding: 12px;
+        margin-top: 10px;
+        font-family: 'Courier New', monospace;
+        font-size: 13px;
+        white-space: pre-wrap;
+        min-height: 60px;
+      }
+      .info {
+        background: #e8f5e9;
+        border-left: 4px solid #4caf50;
+        padding: 10px;
+        margin: 10px 0;
+        font-size: 13px;
+      }
+      .warning {
+        background: #fff3e0;
+        border-left: 4px solid #ff9800;
+        padding: 10px;
+        margin: 10px 0;
+        font-size: 13px;
+      }
+      .comparison {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 15px;
+      }
+      .comparison > div {
+        padding: 15px;
+        border-radius: 8px;
+      }
+      .transfer { background: #e8f5e9; border: 1px solid #4caf50; }
+      .copy { background: #fff3e0; border: 1px solid #ff9800; }
+    </style>
+  </head>
+  <body>
+    <h1>📦 Transferable vs postMessage 内存拷贝对比</h1>
+
+    <div class="info">
+      <strong>核心区别：</strong><br>
+      • <strong>postMessage 普通对象</strong>：结构化克隆算法拷贝，数据复制一份到 Worker<br>
+      • <strong>Transferable 对象</strong>：所有权转移，原对象在主线程被清空，零拷贝
+    </div>
+
+    <div class="card">
+      <h3>内存拷贝对比</h3>
+      <div class="comparison">
+        <div class="copy">
+          <h4 style="color:#ff9800;margin-top:0;">❌ 普通 postMessage（拷贝）</h4>
+          <button onclick="testNormalPostMessage()">传递 50MB 数据（拷贝）</button>
+          <div id="copyResult" class="result">点击按钮测试...</div>
+        </div>
+        <div class="transfer">
+          <h4 style="color:#4caf50;margin-top:0;">✅ Transferable（转移）</h4>
+          <button onclick="testTransferable()">传递 50MB 数据（转移）</button>
+          <div id="transferResult" class="result">点击按钮测试...</div>
+        </div>
+      </div>
+    </div>
+
+    <div class="card">
+      <h3>多次传递累积效果</h3>
+      <p>演示多次 postMessage 大对象导致内存持续增长</p>
+      <button onclick="testMultipleTransfer(10)">10次 Transferable</button>
+      <button onclick="testMultipleCopy(10)">10次 普通拷贝</button>
+      <button onclick="testMultipleTransfer(50)">50次 Transferable</button>
+      <button onclick="testMultipleCopy(50)">50次 普通拷贝</button>
+      <div id="multipleResult" class="result">点击按钮测试...</div>
+    </div>
+
+    <div class="warning">
+      <strong>⚠️ 警告：</strong>普通 postMessage 拷贝大数据时，内存会翻倍！
+      例如：传递 100MB 对象 → 主线程 100MB + Worker 100MB = 200MB
+    </div>
+
+    <div class="card">
+      <h3>内存变化可视化</h3>
+      <div id="memoryVisualization" style="font-family:monospace;font-size:12px;background:#f5f5f5;padding:15px;border-radius:4px;">
+        等待测试...
+      </div>
+    </div>
+
+    <script>
+      const WORKER_URL = 'worker.js';
+      const BUFFER_SIZE = 50 * 1024 * 1024; // 50MB
+
+      let worker = null;
+      let transferredCount = 0;
+      let copiedCount = 0;
+
+      function getWorker() {
+        if (!worker) {
+          worker = new Worker(WORKER_URL);
+          worker.onmessage = handleWorkerMessage;
+        }
+        return worker;
+      }
+
+      function handleWorkerMessage(e) {
+        const { type, byteLength, dataLength } = e.data;
+
+        if (type === 'buffer-received') {
+          updateVisualization('transfer');
+          appendResult('transferResult', `✅ Worker 已接收 ArrayBuffer\n大小: ${(byteLength / (1024*1024)).toFixed(2)} MB\n注意：主线程原 buffer.byteLength = ${buffer.byteLength}（已清零）`);
+        }
+
+        if (type === 'copy-received') {
+          updateVisualization('copy');
+          appendResult('copyResult', `✅ Worker 已接收数据副本\n数组长度: ${dataLength.toLocaleString()}\n主线程原数据不受影响`);
+        }
+      }
+
+      function appendResult(id, text) {
+        document.getElementById(id).textContent = text;
+      }
+
+      function updateVisualization(type) {
+        const el = document.getElementById('memoryVisualization');
+        if (type === 'transfer') {
+          transferredCount++;
+          el.innerHTML = `
+🟢 Transferable 测试进度：${transferredCount}/50
+[${'█'.repeat(transferredCount)}${'░'.repeat(50-transferredCount)}]
+内存稳定：主线程 → Worker（转移所有权，无拷贝）
+          `;
+        } else {
+          copiedCount++;
+          el.innerHTML = `
+🟠 普通拷贝 测试进度：${copiedCount}/50
+[${'█'.repeat(copiedCount)}${'░'.repeat(50-copiedCount)}]
+⚠️ 内存翻倍：主线程 + Worker 各持有一份！
+          `;
+        }
+      }
+
+      let currentBuffer = null;
+
+      function testNormalPostMessage() {
+        // 创建普通数组（会被拷贝）
+        const data = new Array(12.5 * 1024 * 1024); // 模拟 100MB (8 bytes * 12.5M ≈ 100MB)
+        data.fill(1);
+
+        appendResult('copyResult', '正在传递 100MB 数组（触发拷贝）...');
+
+        const w = getWorker();
+        w.postMessage({ type: 'normal-copy', data }, [data]); // 注意：这里传了 transfer 但 data 不是 Transferable
+      }
+
+      function testTransferable() {
+        // 创建 ArrayBuffer（是 Transferable）
+        const buffer = new ArrayBuffer(BUFFER_SIZE);
+        const view = new DataView(buffer);
+        for (let i = 0; i < view.byteLength; i += 1000000) {
+          view.setUint8(i, 1);
+        }
+
+        // 先记录原始大小
+        currentBuffer = buffer;
+        const originalSize = buffer.byteLength;
+
+        appendResult('transferResult', `正在传递 ${(originalSize/(1024*1024)).toFixed(2)}MB ArrayBuffer（所有权转移）...\n主线程 buffer.byteLength = ${originalSize}`);
+
+        const w = getWorker();
+        w.postMessage({ type: 'transfer-buffer', buffer: buffer }, [buffer]);
+
+        // 验证所有权转移后原 buffer 被清空
+        setTimeout(() => {
+          if (currentBuffer) {
+            appendResult('transferResult', `✅ Worker 已接收\n\n验证所有权转移效果：\n主线程 buffer.byteLength = ${currentBuffer.byteLength}（已清零！）`);
+          }
+        }, 100);
+      }
+
+      let transferBuffers = [];
+      let copyDataArrays = [];
+
+      async function testMultipleTransfer(count) {
+        transferredCount = 0;
+        appendResult('multipleResult', `开始 ${count} 次 Transferable 测试...`);
+
+        for (let i = 0; i < count; i++) {
+          const buffer = new ArrayBuffer(BUFFER_SIZE);
+          transferBuffers.push(buffer);
+          const w = new Worker(WORKER_URL);
+          w.postMessage({ type: 'transfer-buffer', buffer: buffer }, [buffer]);
+          await new Promise(r => setTimeout(r, 10));
+        }
+
+        appendResult('multipleResult', `✅ 完成 ${count} 次 Transferable\n\n内存稳定：所有权立即转移，主线程缓冲区清零\n理论上内存峰值 ≈ 单个 buffer 大小`);
+        transferBuffers = [];
+      }
+
+      async function testMultipleCopy(count) {
+        copiedCount = 0;
+        appendResult('multipleResult', `开始 ${count} 次普通拷贝测试...`);
+
+        for (let i = 0; i < count; i++) {
+          const data = new Array(12.5 * 1024 * 1024);
+          data.fill(i);
+          copyDataArrays.push(data);
+          const w = new Worker(WORKER_URL);
+          w.postMessage({ type: 'normal-copy', data });
+          await new Promise(r => setTimeout(r, 10));
+        }
+
+        appendResult('multipleResult', `⚠️ 完成 ${count} 次普通拷贝\n\n内存问题：主线程和 Worker 各持有一份副本！\n如果每次 100MB，${count} 次后主线程仍持有 ${(count * 100).toFixed(0)}MB 数据\n直到这些对象被 GC 回收`);
+        copyDataArrays = [];
+      }
+    </script>
+  </body>
+</html>

--- a/examples/browser-api/worker-memory/transferable/index.html
+++ b/examples/browser-api/worker-memory/transferable/index.html
@@ -172,14 +172,14 @@
       let currentBuffer = null;
 
       function testNormalPostMessage() {
-        // 创建普通数组（会被拷贝）
+        // 创建普通数组（会被结构化克隆算法拷贝）
         const data = new Array(12.5 * 1024 * 1024); // 模拟 100MB (8 bytes * 12.5M ≈ 100MB)
         data.fill(1);
 
         appendResult('copyResult', '正在传递 100MB 数组（触发拷贝）...');
 
         const w = getWorker();
-        w.postMessage({ type: 'normal-copy', data }, [data]); // 注意：这里传了 transfer 但 data 不是 Transferable
+        w.postMessage({ type: 'normal-copy', data }); // 普通对象被拷贝传递
       }
 
       function testTransferable() {

--- a/examples/browser-api/worker-memory/transferable/worker.js
+++ b/examples/browser-api/worker-memory/transferable/worker.js
@@ -1,0 +1,28 @@
+// Transferable vs postMessage 拷贝示例
+// Worker 线程：接收 ArrayBuffer 并标记已接收
+
+self.onmessage = function(e) {
+  const { type, buffer } = e.data;
+
+  if (type === 'transfer-buffer') {
+    // 模拟处理 ArrayBuffer 数据
+    const view = new DataView(buffer);
+    const sum = view.byteLength; // 只是读取长度，不实际处理
+
+    self.postMessage({
+      type: 'buffer-received',
+      byteLength: buffer.byteLength,
+      sum
+    });
+  }
+
+  if (type === 'normal-copy') {
+    // 正常拷贝的数据
+    const { data } = e.data;
+    self.postMessage({
+      type: 'copy-received',
+      dataLength: data.length,
+      firstValue: data[0]
+    });
+  }
+};

--- a/examples/cookie/third-party-cookie-demo.html
+++ b/examples/cookie/third-party-cookie-demo.html
@@ -1,0 +1,835 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>第三方 Cookie 交互式演示</title>
+  <style>
+    :root {
+      --primary: #3b82f6;
+      --success: #22c55e;
+      --warning: #f59e0b;
+      --danger: #ef4444;
+      --bg: #f8fafc;
+      --card: #ffffff;
+      --border: #e2e8f0;
+      --text: #1e293b;
+      --text-muted: #64748b;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: var(--bg);
+      color: var(--text);
+      margin: 0;
+      padding: 20px;
+      line-height: 1.6;
+    }
+
+    .container {
+      max-width: 900px;
+      margin: 0 auto;
+    }
+
+    h1 {
+      text-align: center;
+      color: var(--primary);
+      margin-bottom: 8px;
+    }
+
+    .subtitle {
+      text-align: center;
+      color: var(--text-muted);
+      margin-bottom: 32px;
+    }
+
+    .card {
+      background: var(--card);
+      border-radius: 12px;
+      border: 1px solid var(--border);
+      padding: 24px;
+      margin-bottom: 20px;
+      box-shadow: 0 1px 3px rgba(0,0,0,0.05);
+    }
+
+    .card h2 {
+      margin-top: 0;
+      font-size: 1.1rem;
+      color: var(--text);
+      border-bottom: 1px solid var(--border);
+      padding-bottom: 12px;
+    }
+
+    .btn {
+      padding: 8px 16px;
+      border: none;
+      border-radius: 6px;
+      cursor: pointer;
+      font-size: 0.9rem;
+      transition: all 0.2s;
+    }
+
+    .btn-primary {
+      background: var(--primary);
+      color: white;
+    }
+
+    .btn-primary:hover {
+      background: #2563eb;
+    }
+
+    .btn-success {
+      background: var(--success);
+      color: white;
+    }
+
+    .btn-danger {
+      background: var(--danger);
+      color: white;
+    }
+
+    .btn-warning {
+      background: var(--warning);
+      color: white;
+    }
+
+    .btn:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+
+    .grid-2 {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 16px;
+    }
+
+    .cookie-section {
+      padding: 16px;
+      border-radius: 8px;
+      background: #f1f5f9;
+    }
+
+    .cookie-section h3 {
+      margin: 0 0 12px 0;
+      font-size: 0.95rem;
+    }
+
+    .cookie-section.first-party {
+      border-left: 4px solid var(--success);
+    }
+
+    .cookie-section.third-party {
+      border-left: 4px solid var(--danger);
+    }
+
+    .cookie-list {
+      font-family: 'Courier New', monospace;
+      font-size: 0.85rem;
+      background: #0f172a;
+      color: #e2e8f0;
+      padding: 12px;
+      border-radius: 6px;
+      max-height: 120px;
+      overflow-y: auto;
+      word-break: break-all;
+    }
+
+    .cookie-item {
+      padding: 4px 0;
+      display: flex;
+      justify-content: space-between;
+    }
+
+    .cookie-item .name {
+      color: #fbbf24;
+    }
+
+    .cookie-item .value {
+      color: #a5f3fc;
+    }
+
+    .cookie-item .domain {
+      color: #86efac;
+      font-size: 0.8em;
+    }
+
+    .status-badge {
+      display: inline-block;
+      padding: 4px 10px;
+      border-radius: 20px;
+      font-size: 0.85rem;
+      font-weight: 600;
+    }
+
+    .status-available {
+      background: #dcfce7;
+      color: #166534;
+    }
+
+    .status-blocked {
+      background: #fee2e2;
+      color: #991b1b;
+    }
+
+    .status-unknown {
+      background: #fef3c7;
+      color: #92400e;
+    }
+
+    .policy-table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 0.9rem;
+    }
+
+    .policy-table th,
+    .policy-table td {
+      padding: 10px 12px;
+      text-align: left;
+      border-bottom: 1px solid var(--border);
+    }
+
+    .policy-table th {
+      background: #f8fafc;
+      font-weight: 600;
+    }
+
+    .code-block {
+      background: #0f172a;
+      color: #e2e8f0;
+      padding: 16px;
+      border-radius: 8px;
+      font-family: 'Courier New', monospace;
+      font-size: 0.85rem;
+      overflow-x: auto;
+      white-space: pre;
+    }
+
+    .log-area {
+      background: #0f172a;
+      color: #e2e8f0;
+      padding: 16px;
+      border-radius: 8px;
+      font-family: 'Courier New', monospace;
+      font-size: 0.85rem;
+      max-height: 200px;
+      overflow-y: auto;
+    }
+
+    .log-entry {
+      padding: 3px 0;
+    }
+
+    .log-entry.info { color: #60a5fa; }
+    .log-entry.success { color: #4ade80; }
+    .log-entry.warning { color: #fbbf24; }
+    .log-entry.error { color: #f87171; }
+
+    .tabs {
+      display: flex;
+      gap: 8px;
+      margin-bottom: 16px;
+      border-bottom: 2px solid var(--border);
+      padding-bottom: 0;
+    }
+
+    .tab {
+      padding: 8px 16px;
+      cursor: pointer;
+      border: none;
+      background: none;
+      font-size: 0.95rem;
+      color: var(--text-muted);
+      border-bottom: 2px solid transparent;
+      margin-bottom: -2px;
+      transition: all 0.2s;
+    }
+
+    .tab.active {
+      color: var(--primary);
+      border-bottom-color: var(--primary);
+      font-weight: 600;
+    }
+
+    .tab-content {
+      display: none;
+    }
+
+    .tab-content.active {
+      display: block;
+    }
+
+    .detection-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+      gap: 12px;
+    }
+
+    .detection-item {
+      padding: 16px;
+      border-radius: 8px;
+      background: #f1f5f9;
+      text-align: center;
+    }
+
+    .detection-item .icon {
+      font-size: 2rem;
+      margin-bottom: 8px;
+    }
+
+    .detection-item .label {
+      font-size: 0.85rem;
+      color: var(--text-muted);
+      margin-bottom: 4px;
+    }
+
+    .detection-item .value {
+      font-weight: 600;
+      font-size: 1rem;
+    }
+
+    @media (max-width: 640px) {
+      .grid-2 {
+        grid-template-columns: 1fr;
+      }
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>🍪 第三方 Cookie 交互演示</h1>
+    <p class="subtitle">了解第一方 vs 第三方 Cookie 的差异，以及各浏览器策略</p>
+
+    <!-- 浏览器策略概览 -->
+    <div class="card">
+      <h2>🕵️ 浏览器策略检测</h2>
+      <div class="detection-grid">
+        <div class="detection-item">
+          <div class="icon">🌐</div>
+          <div class="label">User Agent</div>
+          <div class="value" id="uaDisplay">-</div>
+        </div>
+        <div class="detection-item">
+          <div class="icon">🍪</div>
+          <div class="label">Cookie 支持</div>
+          <div class="value" id="cookieEnabled">-</div>
+        </div>
+        <div class="detection-item">
+          <div class="icon">🔒</div>
+          <div class="label">SameSite 属性</div>
+          <div class="value" id="samesiteSupport">-</div>
+        </div>
+        <div class="detection-item">
+          <div class="icon">🛡️</div>
+          <div class="label">检测到的策略</div>
+          <div class="value" id="detectedPolicy">-</div>
+        </div>
+      </div>
+    </div>
+
+    <!-- 第一方 vs 第三方 Cookie 设置 -->
+    <div class="card">
+      <h2>🔬 第一方 vs 第三方 Cookie 对比</h2>
+      <p style="color: var(--text-muted); font-size: 0.9rem;">
+        点击按钮设置 Cookie，观察控制台 Network 面板中 Cookie 的 Domain 属性差异。
+      </p>
+
+      <div class="grid-2">
+        <!-- 第一方 Cookie -->
+        <div class="cookie-section first-party">
+          <h3>✅ 第一方 Cookie（当前域）</h3>
+          <p style="font-size: 0.85rem; color: var(--text-muted);">
+            Cookie 设置在当前页面域名下
+          </p>
+          <div style="margin-bottom: 12px;">
+            <label style="font-size: 0.85rem;">Cookie 名：</label>
+            <input type="text" id="firstPartyName" value="user_session" style="width: 120px; padding: 4px; border: 1px solid var(--border); border-radius: 4px;" />
+          </div>
+          <div style="margin-bottom: 12px;">
+            <label style="font-size: 0.85rem;">Cookie 值：</label>
+            <input type="text" id="firstPartyValue" value="abc123" style="width: 120px; padding: 4px; border: 1px solid var(--border); border-radius: 4px;" />
+          </div>
+          <button class="btn btn-success" onclick="setFirstPartyCookie()">设置第一方 Cookie</button>
+        </div>
+
+        <!-- 第三方 Cookie -->
+        <div class="cookie-section third-party">
+          <h3>❌ 第三方 Cookie（跨域）</h3>
+          <p style="font-size: 0.85rem; color: var(--text-muted);">
+            模拟通过第三方脚本设置 Cookie
+          </p>
+          <div style="margin-bottom: 12px;">
+            <label style="font-size: 0.85rem;">Cookie 名：</label>
+            <input type="text" id="thirdPartyName" value="tracker_id" style="width: 120px; padding: 4px; border: 1px solid var(--border); border-radius: 4px;" />
+          </div>
+          <div style="margin-bottom: 12px;">
+            <label style="font-size: 0.85rem;">Cookie 值：</label>
+            <input type="text" id="thirdPartyValue" value="xyz789" style="width: 120px; padding: 4px; border: 1px solid var(--border); border-radius: 4px;" />
+          </div>
+          <button class="btn btn-danger" onclick="setThirdPartyCookie()">尝试设置第三方 Cookie</button>
+          <p id="thirdPartyWarning" style="font-size: 0.8rem; color: var(--warning); margin-top: 8px; display: none;">
+            ⚠️ 现代浏览器已限制第三方 Cookie，请检查控制台
+          </p>
+        </div>
+      </div>
+
+      <!-- Cookie 列表展示 -->
+      <div style="margin-top: 20px;">
+        <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 8px;">
+          <h3 style="margin: 0; font-size: 0.95rem;">📋 当前页面 Cookie 列表</h3>
+          <button class="btn btn-warning" onclick="refreshCookieList()">🔄 刷新</button>
+        </div>
+        <div class="cookie-list" id="cookieList">
+          <div class="log-entry info">点击"刷新"按钮查看当前 Cookie</div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Cookie 拦截检测 -->
+    <div class="card">
+      <h2>🚨 第三方 Cookie 拦截检测工具</h2>
+      <p style="color: var(--text-muted); font-size: 0.9rem;">
+        模拟跨域场景，检测浏览器是否阻止了第三方 Cookie
+      </p>
+
+      <div style="margin-bottom: 16px;">
+        <button class="btn btn-primary" onclick="runDetection()">▶️ 运行检测</button>
+        <button class="btn btn-danger" onclick="clearLog()">🗑️ 清空日志</button>
+      </div>
+
+      <div class="tabs">
+        <button class="tab active" onclick="switchTab('detection-log')">检测日志</button>
+        <button class="tab" onclick="switchTab('how-it-works')">工作原理</button>
+        <button class="tab" onclick="switchTab('solutions')">解决方案</button>
+      </div>
+
+      <div id="detection-log" class="tab-content active">
+        <div class="log-area" id="logArea">
+          <div class="log-entry info">[系统] 点击"运行检测"开始检测</div>
+        </div>
+      </div>
+
+      <div id="how-it-works" class="tab-content">
+        <h4 style="margin-top: 0;">第三方 Cookie 拦截是如何工作的？</h4>
+        <div class="code-block">// 1. 嵌入跨域脚本
+&lt;script src="https://tracker.com/analytics.js"&gt;&lt;/script&gt;
+
+// 2. 第三方脚本尝试写入 Cookie
+// tracker.com/analytics.js
+document.cookie = "uid=xxx; Domain=.tracker.com; Path=/";
+
+// 3. 浏览器拒绝设置（根据 SameSite 策略）
+// 如果页面通过 HTTPS 加载，且 tracker.com 的 SameSite=None; Secure
+// → Cookie 可能被设置（但仍然仅在嵌入 tracker.com 资源的站点发送）
+
+// 4. 关键点：浏览器基于嵌入上下文判断是否发送 Cookie
+// 当请求 siteA.com 嵌入的 tracker.com 资源时：
+//   - 如果 tracker.com 设置了 Partitioned → 仅在 tracker.com 被 siteA.com 嵌入时发送
+//   - 如果 tracker.com 未设置 Partitioned → 在任何站点嵌入时都可能发送
+//   - 如果使用 CHIPS → Cookie 按顶级站点分区存储</div>
+      </div>
+
+      <div id="solutions" class="tab-content">
+        <h4 style="margin-top: 0;">第三方 Cookie 受限时的解决方案</h4>
+        <table class="policy-table">
+          <thead>
+            <tr>
+              <th>方案</th>
+              <th>适用场景</th>
+              <th>状态</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>第一方 Cookie</td>
+              <td>同站用户识别</td>
+              <td><span class="status-badge status-available">✅ 可用</span></td>
+            </tr>
+            <tr>
+              <td>CHIPS</td>
+              <td>嵌入式 Widget</td>
+              <td><span class="status-badge status-available">🟡 部分支持</span></td>
+            </tr>
+            <tr>
+              <td>Related Website Sets</td>
+              <td>同企业多站点 SSO</td>
+              <td><span class="status-badge status-unknown">🟡 有限</span></td>
+            </tr>
+            <tr>
+              <td>Privacy Sandbox</td>
+              <td>广告定向（过渡期）</td>
+              <td><span class="status-badge status-unknown">🟡 推进中</span></td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <!-- SameSite 属性演示 -->
+    <div class="card">
+      <h2>🔐 SameSite 属性演示</h2>
+      <p style="color: var(--text-muted); font-size: 0.9rem;">
+        SameSite 属性控制 Cookie 如何在不同站点间发送
+      </p>
+
+      <table class="policy-table">
+        <thead>
+          <tr>
+            <th>SameSite 值</th>
+            <th>同站 GET 请求</th>
+            <th>跨站 GET 请求</th>
+            <th>跨站 POST 请求</th>
+            <th>说明</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>Strict</code></td>
+            <td>✅ 发送</td>
+            <td>❌ 不发送</td>
+            <td>❌ 不发送</td>
+            <td>最严格，完全阻止跨站</td>
+          </tr>
+          <tr>
+            <td><code>Lax</code></td>
+            <td>✅ 发送</td>
+            <td>✅ 发送（仅导航）</td>
+            <td>❌ 不发送</td>
+            <td>默认值，允许链接跳转但阻止 POST</td>
+          </tr>
+          <tr>
+            <td><code>None</code></td>
+            <td>✅ 发送</td>
+            <td>✅ 发送</td>
+            <td>✅ 发送</td>
+            <td>全部发送，但必须配合 Secure</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <div style="margin-top: 16px;">
+        <h4 style="font-size: 0.95rem;">SameSite=Lax 的实际影响</h4>
+        <div class="code-block">// ✅ 正常登录用户点击链接访问
+&lt;a href="https://other-site.com"&gt;访问其他站点&lt;/a&gt;
+// → 浏览器发送 Lax Cookie（如果是 GET 导航）
+
+// ❌ 从 A 站点提交表单到 B 站点
+&lt;form action="https://other-site.com" method="POST"&gt;
+// → 浏览器阻止发送 Cookie（POST 是"危险"方法）
+
+// ❌ AJAX/fetch 跨站请求
+fetch('https://other-site.com/api', { method: 'POST' })
+// → 浏览器阻止发送 Cookie（JavaScript 发起的请求视为危险）</div>
+      </div>
+    </div>
+
+    <!-- 各浏览器策略 -->
+    <div class="card">
+      <h2>🌍 各浏览器第三方 Cookie 支持现状</h2>
+      <table class="policy-table">
+        <thead>
+          <tr>
+            <th>浏览器</th>
+            <th>第三方 Cookie</th>
+            <th>策略名称</th>
+            <th>备注</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Chrome 120+</td>
+            <td><span class="status-badge status-unknown">🟡 逐步淘汰</span></td>
+            <td>Lax + Privacy Sandbox</td>
+            <td>2025 年完全禁用</td>
+          </tr>
+          <tr>
+            <td>Safari 17+</td>
+            <td><span class="status-badge status-blocked">❌ 完全阻止</span></td>
+            <td>ITP</td>
+            <td>第三方 JS Cookie 仅保留 7 天</td>
+          </tr>
+          <tr>
+            <td>Firefox 120+</td>
+            <td><span class="status-badge status-blocked">❌ 完全阻止</span></td>
+            <td>ETP 严格模式</td>
+            <td>默认启用增强追踪保护</td>
+          </tr>
+          <tr>
+            <td>Edge 120+</td>
+            <td><span class="status-badge status-unknown">🟡 逐步淘汰</span></td>
+            <td>与 Chrome 一致</td>
+            <td>继承 Chromium 策略</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+
+  <script>
+    // =====================
+    // 浏览器策略检测
+    // =====================
+
+    function detectBrowserPolicy() {
+      const ua = navigator.userAgent;
+      let policy = 'Unknown';
+      let browser = 'Unknown';
+
+      if (/Edg\//.test(ua)) {
+        browser = 'Edge';
+        policy = 'Chromium_Lax';
+      } else if (/Chrome\//.test(ua) && !/Chromium/.test(ua)) {
+        browser = 'Chrome';
+        const version = parseInt(ua.match(/Chrome\/(\d+)/)?.[1] || '0');
+        policy = version >= 115 ? 'Chrome_Sandbox_Gradual' : 'Chrome_Lax';
+      } else if (/Safari\//.test(ua) && !/Chrome/.test(ua)) {
+        browser = 'Safari';
+        policy = 'ITP_FullBlock';
+      } else if (/Firefox\//.test(ua)) {
+        browser = 'Firefox';
+        policy = 'ETP_Strict';
+      }
+
+      return { browser, policy };
+    }
+
+    function detectSameSiteSupport() {
+      // 检测浏览器是否支持 SameSite 属性
+      const dummyCookie = '__samesite_test=' + Math.random();
+      document.cookie = dummyCookie + '; path=/';
+      const supported = document.cookie.includes(dummyCookie);
+      document.cookie = dummyCookie + '=; max-age=0; path=/';
+      return supported;
+    }
+
+    function initBrowserDetection() {
+      // UA 显示
+      const uaDisplay = document.getElementById('uaDisplay');
+      const ua = navigator.userAgent;
+      const shortUa = ua.length > 50 ? ua.substring(0, 50) + '...' : ua;
+      uaDisplay.textContent = shortUa;
+
+      // Cookie 是否启用
+      const cookieEnabledEl = document.getElementById('cookieEnabled');
+      const cookieEnabled = navigator.cookieEnabled;
+      cookieEnabledEl.innerHTML = cookieEnabled
+        ? '<span class="status-badge status-available">✅ 启用</span>'
+        : '<span class="status-badge status-blocked">❌ 禁用</span>';
+
+      // SameSite 支持
+      const samesiteEl = document.getElementById('samesiteSupport');
+      const sameSiteSupport = detectSameSiteSupport();
+      samesiteEl.innerHTML = sameSiteSupport
+        ? '<span class="status-badge status-available">✅ 支持</span>'
+        : '<span class="status-badge status-unknown">⚠️ 不确定</span>';
+
+      // 检测到的策略
+      const policyEl = document.getElementById('detectedPolicy');
+      const { browser, policy } = detectBrowserPolicy();
+      const policyLabels = {
+        'Chrome_Sandbox_Gradual': 'Chrome 逐步淘汰',
+        'Chrome_Lax': 'Chrome SameSite=Lax',
+        'ITP_FullBlock': 'Safari ITP 完全阻止',
+        'ETP_Strict': 'Firefox ETP 严格',
+        'Chromium_Lax': 'Edge SameSite=Lax',
+        'Unknown': '未识别'
+      };
+      policyEl.innerHTML = `<span class="status-badge status-${policy === 'Unknown' ? 'unknown' : 'available'}">${browser} - ${policyLabels[policy] || policy}</span>`;
+    }
+
+    // =====================
+    // Cookie 操作
+    // =====================
+
+    function setFirstPartyCookie() {
+      const name = document.getElementById('firstPartyName').value.trim() || 'user_session';
+      const value = document.getElementById('firstPartyValue').value.trim() || 'first_party_' + Date.now();
+
+      // 第一方 Cookie：无需指定 Domain，默认为当前页面域名
+      const cookieStr = `${name}=${value}; Path=/; Max-Age=${60 * 60 * 24 * 30}; SameSite=Lax`;
+      document.cookie = cookieStr;
+
+      addLog(`✅ 已设置第一方 Cookie: ${name}=${value}`, 'success');
+      addLog(`   Cookie 字符串: ${cookieStr}`, 'info');
+      addLog(`   效果：该 Cookie 仅在当前站点发送，不会跨站发送`, 'info');
+
+      refreshCookieList();
+    }
+
+    function setThirdPartyCookie() {
+      const name = document.getElementById('thirdPartyName').value.trim() || 'tracker_id';
+      const value = document.getElementById('thirdPartyValue').value.trim() || 'third_party_' + Date.now();
+
+      // 第三方 Cookie：设置不同的 Domain（如第三方域名）
+      // 注意：在现代浏览器中，这种方式实际上无法实现真正的"第三方"Cookie
+      // 浏览器会拒绝来自当前页面域名设置其他域名的 Cookie
+      // 这里演示的是概念
+
+      const fakeDomainCookie = `${name}=${value}; Domain=.third-party-demo.com; Path=/; Max-Age=${60 * 60 * 24 * 30}`;
+
+      addLog(`🔍 尝试设置第三方 Cookie: ${name}=${value}`, 'warning');
+      addLog(`   Cookie 字符串: ${fakeDomainCookie}`, 'info');
+
+      // 尝试设置（实际会失败，因为浏览器限制跨域 Cookie）
+      document.cookie = fakeDomainCookie;
+
+      // 检查是否设置成功
+      const allCookies = document.cookie;
+      if (allCookies.includes(name)) {
+        addLog(`⚠️ Cookie 被设置成功（浏览器可能处于宽松模式）`, 'warning');
+      } else {
+        addLog(`❌ Cookie 设置被阻止（浏览器 SameSite=Lax 或更严格策略生效）`, 'error');
+      }
+
+      // 显示警告
+      document.getElementById('thirdPartyWarning').style.display = 'block';
+      refreshCookieList();
+    }
+
+    function refreshCookieList() {
+      const cookieListEl = document.getElementById('cookieList');
+      const cookies = document.cookie;
+
+      if (!cookies) {
+        cookieListEl.innerHTML = '<div class="log-entry warning">当前页面没有 Cookie</div>';
+        return;
+      }
+
+      const cookieItems = cookies.split(';').map(c => c.trim());
+      let html = '';
+
+      cookieItems.forEach(item => {
+        const [nameValue] = item.split(';');
+        const [name, value] = nameValue.split('=');
+        html += `<div class="cookie-item">
+          <span class="name">${name || '(无名称)'}</span>
+          <span class="value">${value || '(无值)'}</span>
+        </div>`;
+      });
+
+      cookieListEl.innerHTML = html || '<div class="log-entry info">无法解析 Cookie</div>';
+    }
+
+    // =====================
+    // 检测工具
+    // =====================
+
+    function addLog(message, type = 'info') {
+      const logArea = document.getElementById('logArea');
+      const timestamp = new Date().toLocaleTimeString();
+      const entry = document.createElement('div');
+      entry.className = `log-entry ${type}`;
+      entry.textContent = `[${timestamp}] ${message}`;
+      logArea.appendChild(entry);
+      logArea.scrollTop = logArea.scrollHeight;
+    }
+
+    function clearLog() {
+      document.getElementById('logArea').innerHTML =
+        '<div class="log-entry info">[系统] 日志已清空</div>';
+    }
+
+    async function runDetection() {
+      addLog('='.repeat(50), 'info');
+      addLog('开始第三方 Cookie 检测...', 'info');
+
+      // 检测 1: Cookie 是否启用
+      addLog('检测 1: navigator.cookieEnabled', 'info');
+      if (navigator.cookieEnabled) {
+        addLog('✅ 第一方 Cookie: 已启用', 'success');
+      } else {
+        addLog('❌ Cookie 已完全禁用', 'error');
+        return;
+      }
+
+      // 检测 2: SameSite 支持
+      addLog('检测 2: SameSite 属性支持', 'info');
+      const sameSiteSupport = detectSameSiteSupport();
+      if (sameSiteSupport) {
+        addLog('✅ SameSite 属性: 支持', 'success');
+      } else {
+        addLog('⚠️ SameSite 属性: 不支持或行为异常', 'warning');
+      }
+
+      // 检测 3: 尝试写入测试 Cookie
+      addLog('检测 3: 写入测试 Cookie', 'info');
+      const testCookieName = '__cookie_test_' + Date.now();
+      document.cookie = `${testCookieName}=1; Path=/; Max-Age=10`;
+      const canWrite = document.cookie.includes(testCookieName);
+      document.cookie = `${testCookieName}=; Max-Age=0; Path=/`;
+
+      if (canWrite) {
+        addLog('✅ Cookie 写入: 成功（SameSite 策略可能较宽松）', 'success');
+      } else {
+        addLog('⚠️ Cookie 写入: 受限（SameSite=Lax 或更严格）', 'warning');
+      }
+
+      // 检测 4: 检测第三方脚本写入能力（模拟）
+      addLog('检测 4: 第三方脚本 Cookie 写入能力', 'info');
+      addLog('   （无法在同源环境下真实模拟，此为理论分析）', 'info');
+
+      const { policy } = detectBrowserPolicy();
+      if (policy.includes('ITP') || policy.includes('ETP')) {
+        addLog('❌ 第三方 Cookie: 会被完全阻止', 'error');
+        addLog('   建议：迁移到第一方 Cookie 或 CHIPS', 'warning');
+      } else if (policy.includes('Lax') || policy.includes('Gradual')) {
+        addLog('⚠️ 第三方 Cookie: SameSite=Lax 生效，跨站请求受限', 'warning');
+        addLog('   建议：使用 SameSite=None; Secure，或迁移到 Privacy Sandbox', 'info');
+      }
+
+      // 检测 5: Storage API 降级检测
+      addLog('检测 5: localStorage 降级', 'info');
+      try {
+        localStorage.setItem('__test', '1');
+        localStorage.removeItem('__test');
+        addLog('✅ localStorage: 可用', 'success');
+      } catch (e) {
+        addLog('❌ localStorage: 不可用（可能是隐私模式）', 'error');
+      }
+
+      // 检测 6: sessionStorage
+      addLog('检测 6: sessionStorage 降级', 'info');
+      try {
+        sessionStorage.setItem('__test', '1');
+        sessionStorage.removeItem('__test');
+        addLog('✅ sessionStorage: 可用', 'success');
+      } catch (e) {
+        addLog('❌ sessionStorage: 不可用', 'error');
+      }
+
+      addLog('='.repeat(50), 'info');
+      addLog('检测完成。建议：检查日志中的 ⚠️ 和 ❌ 项。', 'info');
+    }
+
+    // =====================
+    // Tab 切换
+    // =====================
+
+    function switchTab(tabId) {
+      // 移除所有 active 类
+      document.querySelectorAll('.tab').forEach(t => t.classList.remove('active'));
+      document.querySelectorAll('.tab-content').forEach(c => c.classList.remove('active'));
+
+      // 激活目标 tab
+      document.querySelector(`.tab[onclick="switchTab('${tabId}')"]`).classList.add('active');
+      document.getElementById(tabId).classList.add('active');
+    }
+
+    // =====================
+    // 初始化
+    // =====================
+
+    document.addEventListener('DOMContentLoaded', () => {
+      initBrowserDetection();
+      refreshCookieList();
+      addLog('🍪 第三方 Cookie 演示工具已就绪', 'success');
+      addLog('📌 提示：在控制台 Network 面板中可查看 Cookie 的详细信息', 'info');
+    });
+  </script>
+</body>
+</html>

--- a/guide/03.agent/01.browser/05.worker.md
+++ b/guide/03.agent/01.browser/05.worker.md
@@ -1,0 +1,265 @@
+# [Worker](https://developer.mozilla.org/en-US/docs/Web/API/Worker)
+
+## 进程与内存模型
+
+### Worker 运行在哪个进程？
+
+**关键结论：Worker 运行在渲染进程内，但有独立的内存空间。**
+
+浏览器进程架构大致如下：
+
+```
+┌─────────────────────────────────────────────────────┐
+│                    浏览器进程                        │
+│  (地址空间、文件句柄、全局状态)                       │
+├─────────────────────────────────────────────────────┤
+│                   渲染进程                            │
+│  ┌──────────────┐  ┌──────────────┐                │
+│  │   主线程      │  │  Worker 线程  │                │
+│  │  (V8 堆)     │  │  (独立 V8 堆) │                │
+│  │              │  │              │                │
+│  │  DOM         │  │  无 DOM       │                │
+│  │  JS 全局对象  │  │  独立全局对象  │                │
+│  └──────────────┘  └──────────────┘                │
+│                                                      │
+│  两个线程共享渲染进程地址空间，但不共享 JavaScript 对象 │
+└─────────────────────────────────────────────────────┘
+```
+
+### 不同类型 Worker 的内存模型
+
+| Worker 类型 | 运行位置 | 内存来源 | 生命周期 |
+|------------|---------|---------|---------|
+| **DedicatedWorker** | 渲染进程内 | 渲染进程的 V8 堆（独立） | 与创建它的页面同生同灭 |
+| **SharedWorker** | 渲染进程内 | 渲染进程的 V8 堆（共享） | 所有引用它的标签页共享 |
+| **ServiceWorker** | **独立进程** | 独立进程的 V8 堆 | 独立于页面，可后台运行 |
+| **Worklet** | 渲染进程内 | 渲染进程的 V8 堆 | 短暂存在，任务结束即释放 |
+
+**DedicatedWorker 内存示意图：**
+
+```
+渲染进程 V8 堆内存
+┌─────────────────────┬─────────────────────┐
+│     主线程 V8 堆     │  DedicatedWorker V8 堆│
+│                     │                     │
+│  main.js 栈/堆      │   worker.js 栈/堆    │
+│  ┌─────────────┐   │   ┌─────────────┐   │
+│  │ globalVars  │   │   │ workerVars  │   │
+│  │ {data: 100MB}│   │   │ {calc: ...} │   │
+│  └─────────────┘   │   └─────────────┘   │
+│                     │                     │
+│  postMessage()  ────拷贝───────────────>│
+│  (大对象复制，内存翻倍)                   │
+└─────────────────────┴─────────────────────┘
+```
+
+### ServiceWorker 的特殊之处
+
+ServiceWorker 运行在**独立进程**，不依附于任何渲染进程：
+
+```
+┌─────────────────┐  ┌─────────────────┐  ┌─────────────────┐
+│   渲染进程 A    │  │   渲染进程 B    │  │   渲染进程 C    │
+│   (标签页 A)    │  │   (标签页 B)    │  │   (标签页 C)    │
+└────────┬────────┘  └────────┬────────┘  └────────┬────────┘
+         │                      │                      │
+         └──────────────────────┼──────────────────────┘
+                                │
+                    ┌───────────▼───────────┐
+                    │   ServiceWorker      │
+                    │   (独立进程)          │
+                    │   独立 V8 堆          │
+                    └─────────────────────┘
+```
+
+## Worker 内存分配机制
+
+### 内存来源
+
+Worker 分配的内存**从渲染进程的 V8 堆中分配**，但使用独立的 V8 实例：
+
+```js
+// main.js - 主线程
+const worker = new Worker('worker.js');
+
+// worker.js - Worker 线程
+// 这里分配的内存来自渲染进程 V8 堆，但与主线程独立
+const largeArray = new Array(10 * 1024 * 1024); // 约 80MB
+console.log(largeArray.length); // 10000000
+```
+
+### 内存是否"叠加"？
+
+**会叠加，但不是简单的相加。**
+
+- Worker 的内存是渲染进程 V8 总堆内存的一部分
+- 主线程和 Worker 各有独立的 V8 堆，互不重叠
+- 进程总内存 = 主线程堆 + Worker 堆 + 共享开销
+
+可以用 Chrome DevTools 验证：
+
+```
+Memory 面板 → 左侧选择 "JavaScript VM 实例"
+→ 可以看到主线程和 Worker 的独立堆
+```
+
+## postMessage 与内存拷贝
+
+### 问题：postMessage 大对象的代价
+
+使用 `postMessage` 传递大对象时，数据会被**结构化克隆算法（Structured Clone）拷贝**：
+
+```js
+// main.js
+const bigData = new Array(10 * 1024 * 1024); // 80MB
+worker.postMessage({ data: bigData }); // 触发 80MB 拷贝
+console.log(bigData.length); // 主线程仍持有这份数据
+
+// 内存变化：
+// 拷贝前：主线程 80MB
+// 拷贝后：主线程 80MB + Worker 80MB = 160MB
+```
+
+### 拷贝过程示意
+
+```
+postMessage({ data: bigArray })
+         │
+         ▼ 结构化克隆算法
+    ┌────────────┐
+    │  序列化     │  遍历对象，构建新的内存副本
+    │  bigArray  │  这是一个递归过程，大对象耗时显著
+    └─────┬──────┘
+          │ 生成独立副本
+          ▼
+    ┌────────────┐
+    │ Worker 堆  │  Worker 获得完整副本
+    │ bigArray   │
+    └────────────┘
+
+主线程和 Worker 各持有一份完整数据
+```
+
+### Transferable 对象：零拷贝转移
+
+使用 `Transferable` 接口转移所有权，**原对象被清空**：
+
+```js
+// main.js
+const buffer = new ArrayBuffer(100 * 1024 * 1024); // 100MB
+worker.postMessage(buffer, [buffer]); // 转移所有权
+
+console.log(buffer.byteLength); // 0 - 所有权已转移，缓冲区被清空
+
+// 内存变化：
+// 转移前：主线程 100MB
+// 转移后：主线程 0MB + Worker 100MB = 仍是 100MB（无拷贝开销）
+```
+
+常见 Transferable 类型：
+
+| 类型 | 说明 |
+|-----|------|
+| `ArrayBuffer` | 固定长度二进制缓冲区 |
+| `MessagePort` | 消息端口 |
+| `ImageBitmap` | 位图数据 |
+| `OffscreenCanvas` | 离屏画布 |
+| `ReadableStream` / `WritableStream` | 流对象 |
+
+### SharedArrayBuffer：共享内存
+
+`SharedArrayBuffer` 允许多个线程共享同一块内存，**无需拷贝**：
+
+```js
+// main.js
+const sharedBuffer = new SharedArrayBuffer(100 * 1024 * 1024);
+const mainView = new Int32Array(sharedBuffer);
+worker.postMessage({ sharedBuffer }, [sharedBuffer]);
+
+// worker.js
+self.onmessage = (e) => {
+  const workerView = new Int32Array(e.data.sharedBuffer);
+  workerView[0] = 42; // 主线程立即可见
+};
+```
+
+⚠️ **注意**：使用 `SharedArrayBuffer` 需要配合 `SharedArrayBuffer` 隔离策略和 `crossOriginIsolation`：
+
+```js
+// 服务器响应头
+'Cross-Origin-Embedder-Policy': 'require-corp',
+'Cross-Origin-Opener-Policy': 'same-origin'
+```
+
+## 实际影响与建议
+
+### 实际影响
+
+1. **Worker 内存独立计算**：Worker 分配的内存从渲染进程的 V8 堆中分配
+2. **不直接占用主线程内存**：但会增加渲染进程的总内存使用
+3. **postMessage 大对象**：大对象被拷贝，显著增加内存占用
+4. **Transferable vs SharedArrayBuffer**：
+   - Transferable：转移所有权，不拷贝，适合一次性大数据传递
+   - SharedArrayBuffer：共享内存，无需拷贝，适合频繁读写场景
+
+### 使用建议
+
+- **计算密集型任务**：使用 Worker，避免阻塞主线程
+- **大文件/大数据处理**：使用 Worker + Transferable 对象
+- **频繁数据交换**：使用 SharedArrayBuffer
+- **避免大对象 postMessage**：每次传递都会完整拷贝，造成内存翻倍
+- **及时终止 Worker**：用完后调用 `worker.terminate()`，释放内存
+
+```js
+// 正确做法：大数据用 Transferable
+const buffer = new ArrayBuffer(100 * 1024 * 1024);
+worker.postMessage(buffer, [buffer]);
+
+// 正确做法：不再使用时终止
+worker.terminate();
+```
+
+## 调试 Worker 内存
+
+### Chrome DevTools Memory 面板
+
+1. 拍 Heap Snapshot
+2. 在 "JavaScript VM instances" 筛选 Worker
+3. 对比主线程和 Worker 的堆大小
+
+### performance.memory
+
+```js
+// 仅 Chrome 可用
+console.log(performance.memory);
+// {
+//   jsHeapSizeLimit: 2197815296,
+//   totalJSHeapSize: 15000000,    // 当前 JS 堆总大小
+//   usedJSHeapSize: 12000000      // 已使用的 JS 堆
+// }
+```
+
+### 监控 Worker 内存
+
+```js
+// worker.js - 定期报告内存使用
+setInterval(() => {
+  if (performance.memory) {
+    const { usedJSHeapSize, totalJSHeapSize } = performance.memory;
+    self.postMessage({
+      type: 'memory-report',
+      used: usedJSHeapSize,
+      total: totalJSHeapSize
+    });
+  }
+}, 5000);
+```
+
+### 常见内存问题
+
+| 问题 | 症状 | 解决方案 |
+|-----|------|---------|
+| postMessage 大对象拷贝 | 内存翻倍、页面卡顿 | 使用 Transferable 对象 |
+| Worker 未终止 | 内存持续增长 | 完成后调用 `terminate()` |
+| Worker 闭包泄漏 | Worker 堆内存持续增长 | 避免在 Worker 中保存大对象引用 |
+| SharedArrayBuffer 滥用 | 多线程同时写入冲突 | 使用 Atomics 保证原子性 |


### PR DESCRIPTION
## Summary

添加完整的第三方 Cookie（Third-party Cookie）技术文档，包含以下内容：

### 新增内容

#### 1. 基础概念（docs/cookie/third-party-cookie-overview.md）
- 什么是第三方 Cookie
- 第一方 Cookie vs 第三方 Cookie 对比
- Cookie 的基本工作机制（Domain/Path/SameSite）

#### 2. 核心用途
- 跨域追踪（阿里妈妈 mmstat 案例）
- 广告定向（Facebook Pixel 案例）
- 会话共享（淘宝/天猫 SSO 案例）

#### 3. 工作原理
- 同源策略与 Cookie 共享
- 第三方域名的 Cookie 写入机制
- 附带与非附带的 Cookie

#### 4. 浏览器策略变化
- Chrome 淘汰时间线
- Safari ITP / Firefox ETP 策略
- 各浏览器支持现状对比表

#### 5. 替代方案
- First-party Sets / Related Website Sets
- Privacy Sandbox API（Topics / Protected Audience / Attribution Reporting）
- CHIPS（分区 Cookie）
- 其他技术方案对比

#### 6. 开发者应对策略
- 第三方 Cookie 可用性检测
- 渐进式降级方案
- 迁移到第一方 Cookie 的最佳实践

### 交互式演示（examples/cookie/third-party-cookie-demo.html）
- 浏览器策略自动检测
- 第一方 vs 第三方 Cookie 设置对比
- 第三方 Cookie 拦截检测工具
- SameSite 属性可视化说明
- 各浏览器策略现状表

### Reference
基于掘金文章 [当浏览器全面禁用三方 Cookie](https://juejin.cn/post/6844904128557105166) 整理扩充。