### PR TITLE
docs(ssl): add SSL/TLS certificate issues guide and interactive demo

### DIFF
--- a/docs/axios/adapter-pattern.md
+++ b/docs/axios/adapter-pattern.md
@@ -1,0 +1,353 @@
+# Axios Adapter 适配器模式
+
+## 概述
+
+Axios 是一个基于 Promise 的 HTTP 客户端，支持浏览器和 Node.js 环境。其核心设计理念之一是**适配器模式（Adapter Pattern）**：通过统一的接口，屏蔽不同环境的 HTTP 请求实现差异，让上层调用代码保持一致。
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                        Axios Core                           │
+│  ┌─────────────┐  ┌──────────────┐  ┌─────────────────┐  │
+│  │ Interceptors│→ │ dispatchRequest│→│  Adapter (xhr)  │  │
+│  │             │  │              │  │  Adapter (http) │  │
+│  │             │  │              │  │  Adapter (mock)  │  │
+│  └─────────────┘  └──────────────┘  └─────────────────┘  │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## 适配器接口
+
+### 接口签名
+
+```typescript
+// 适配器是一个接收 config，返回 Promise<Response> 的函数
+interface AxiosAdapter {
+  (config: AxiosRequestConfig): Promise<AxiosResponse>;
+}
+```
+
+### 请求阶段划分
+
+| 阶段 | 说明 | 可干预点 |
+|------|------|----------|
+| 1. 配置合并 | defaults + config 深度合并 | config |
+| 2. 请求转换器 | transformRequest 序列化 data | transformRequest |
+| 3. 请求拦截器 | 请求前统一处理（如加 header） | interceptors.request |
+| **4. 适配器执行** | **实际发送 HTTP 请求** | **adapter** |
+| 5. 响应拦截器 | 响应后统一处理（如错误转换） | interceptors.response |
+| 6. 响应转换器 | transformResponse 反序列化 | transformResponse |
+
+**适配器是唯一真正发起网络请求的地方。**
+
+## 内置适配器
+
+### 1. xhr.js（浏览器环境）
+
+**实现**：XMLHttpRequest
+
+**源码路径**：`lib/adapters/xhr.js`
+
+**核心流程**：
+
+```javascript
+// 简化流程
+export default function xhrAdapter(config) {
+  return new Promise((resolve, reject) => {
+    const request = new XMLHttpRequest();
+    
+    // 1. 打开连接
+    request.open(config.method, config.url, true);
+    
+    // 2. 设置超时
+    request.timeout = config.timeout;
+    
+    // 3. 设置请求头
+    Object.entries(headers).forEach(([k, v]) => 
+      request.setRequestHeader(k, v)
+    );
+    
+    // 4. 处理跨域 Cookie
+    request.withCredentials = !!config.withCredentials;
+    
+    // 5. 设置响应类型
+    if (config.responseType) {
+      request.responseType = config.responseType;
+    }
+    
+    // 6. 注册进度事件（上传/下载）
+    if (config.onUploadProgress) {
+      request.upload.addEventListener('progress', onUploadProgress);
+    }
+    
+    // 7. 注册事件处理器
+    request.onloadend = () => {
+      const response = {
+        data: request.response,
+        status: request.status,
+        statusText: request.statusText,
+        headers: parseHeaders(request.getAllResponseHeaders()),
+        config,
+        request
+      };
+      settle(resolve, reject, response);
+    };
+    
+    request.onabort = () => reject(new AxiosError('Request aborted'));
+    request.onerror = () => reject(new AxiosError('Network Error'));
+    request.ontimeout = () => reject(new AxiosError('timeout exceeded'));
+    
+    // 8. 发送请求
+    request.send(config.data);
+  });
+}
+```
+
+**关键特性**：
+- 上传/下载进度追踪
+- 请求取消（abort）
+- 跨域 withCredentials
+- 多种 responseType（json/text/blob/document/arraybuffer）
+- 自动处理 data: URI 协议
+
+### 2. http.js（Node.js 环境）
+
+**实现**：Node.js 原生 `http` / `https` 模块
+
+**源码路径**：`lib/adapters/http.js`
+
+**核心能力**：
+
+| 特性 | 实现方式 |
+|------|----------|
+| 重定向跟随 | `follow-redirects` 库 |
+| HTTP/2 | `http2.connect()` |
+| 代理 | `proxy-from-env` + `beforeRedirects` 钩子 |
+| 流式响应 | `stream.Readable` 支持 |
+| 进度追踪 | `stream.pipeline` + `progressEventReducer` |
+| 取消 | `EventEmitter` + `AbortController` |
+
+**关键差异**：
+- 支持 HTTP/2 多路复用（Session 连接池）
+- 支持代理自动发现（环境变量 `HTTP_PROXY`）
+- 支持 `socketPath` 替代主机端口
+- 支持 Gzip/Brotli 自动解压
+
+### 适配器选择逻辑
+
+```javascript
+// lib/adapters/adapterResolutionUtils.js
+function getAdapter(adapters) {
+  // 1. 优先使用用户指定的 adapter
+  if (config.adapter) {
+    return adapters[config.adapter];
+  }
+  
+  // 2. 根据环境自动选择
+  adapters = adapters || [xhrAdapter, httpAdapter];
+  
+  const { knownAdapters, supportsRead } = utils;
+  
+  // 遍历适配器列表，返回第一个支持的
+  for (const adapter of adapters) {
+    if (typeof adapter === 'function') {
+      // 检查适配器是否可用（如 xhr 需 XMLHttpRequest）
+      if (adapter.request) {
+        return adapter.request;
+      }
+      return adapter;
+    }
+  }
+}
+```
+
+## 自定义适配器
+
+### 场景一：Mock 适配器（测试环境）
+
+```javascript
+// mock-adapter.js
+function mockAdapter(config) {
+  return new Promise((resolve, reject) => {
+    // 模拟网络延迟
+    setTimeout(() => {
+      const response = {
+        data: { mocked: true, config },
+        status: 200,
+        statusText: 'OK',
+        headers: { 'content-type': 'application/json' },
+        config,
+        request: null
+      };
+
+      // 可通过 config 模拟错误
+      if (config.forceError) {
+        reject(new AxiosError('Mock Error', 'ERR.Mock', config));
+        return;
+      }
+
+      // 模拟 404
+      if (config.mockStatus === 404) {
+        response.status = 404;
+        response.statusText = 'Not Found';
+      }
+
+      settle(resolve, reject, response);
+    }, config.mockDelay || 100);
+  });
+}
+
+// 注册为默认适配器
+axios.defaults.adapter = mockAdapter;
+```
+
+### 场景二：重试适配器
+
+```javascript
+// retry-adapter.js
+const originalAdapter = axios.defaults.adapter;
+
+function retryAdapter(config) {
+  const maxRetries = config.retryCount || 3;
+  const retryDelay = config.retryDelay || 1000;
+  const retryStatuses = [408, 429, 500, 502, 503, 504];
+
+  function attempt(retryCount) {
+    return originalAdapter(config)
+      .catch(err => {
+        if (retryCount < maxRetries) {
+          const shouldRetry = 
+            retryStatuses.includes(err.response?.status) ||
+            err.code === 'ECONNRESET' ||
+            err.code === 'ETIMEDOUT';
+          
+          if (shouldRetry) {
+            return new Promise(resolve => 
+              setTimeout(() => resolve(attempt(retryCount + 1)), retryDelay)
+            );
+          }
+        }
+        throw err;
+      });
+  }
+
+  return attempt(0);
+}
+
+axios.defaults.adapter = retryAdapter;
+```
+
+### 场景三：微信小程序适配器
+
+```javascript
+// wx-adapter.js
+function wxAdapter(config) {
+  return new Promise((resolve, reject) => {
+    wx.request({
+      url: config.url,
+      method: config.method,
+      data: config.data,
+      header: config.headers,
+      success: (res) => {
+        resolve({
+          data: res.data,
+          status: res.statusCode,
+          statusText: '',
+          headers: res.header,
+          config,
+          request: res
+        });
+      },
+      fail: (err) => {
+        reject(new AxiosError(err.errMsg, 'ERR.NETWORK', config));
+      }
+    });
+  });
+}
+```
+
+## settle 函数
+
+`settle` 是适配器与 Promise 桥接的关键函数：
+
+```javascript
+// lib/core/settle.js
+function settle(resolve, reject, response) {
+  const validateStatus = response.config.validateStatus;
+  
+  if (!response.status || !validateStatus || validateStatus(response.status)) {
+    resolve(response);
+  } else {
+    reject(new AxiosError(
+      'Request failed with status ' + response.status,
+      [AxiosError.ERR_BAD_RESPONSE, AxiosError.ERR_BAD_REQUEST][Math.floor(response.status / 100) - 4],
+      response.config,
+      response.request,
+      response
+    ));
+  }
+}
+```
+
+**行为规则**：
+- `2xx` 状态码 → resolve
+- 非 2xx 状态码 → reject（除非 `validateStatus` 返回 true）
+- 无状态码（网络错误）→ reject
+
+## 与拦截器/转换器的区别
+
+| 机制 | 层级 | 执行次数 | 典型用途 |
+|------|------|----------|----------|
+| **Adapter** | 底层网络 | 精确 1 次 | 跨平台适配、Mock |
+| **Interceptor** | 请求/响应 | 可多次 | Header 注入、日志、错误统一处理 |
+| **Transform** | 数据转换 | 精确 1 次 | JSON 解析、请求序列化 |
+
+```
+请求流程：
+  User Config
+       ↓
+  [Transformer: transformRequest] ← 可修改 data
+       ↓
+  [Interceptor: request.use] ← 可修改 config
+       ↓
+  [Adapter: xhr/http] ← 实际网络请求
+       ↓
+  [Interceptor: response.use] ← 可修改 response
+       ↓
+  [Transformer: transformResponse] ← 可修改 data
+       ↓
+  User
+```
+
+## Adapter 与 AxiosError
+
+适配器抛出的错误应使用 `AxiosError`：
+
+```javascript
+// AxiosError 构造签名
+new AxiosError(message, code, config, request, response);
+
+// 常用错误码
+ERR_NETWORK      // 网络错误（如断网）
+ECONNABORTED     // 请求超时
+ERR_BAD_RESPONSE // 非 2xx 响应
+ERR_BAD_REQUEST  // 4xx 响应
+ERR_CANCELED     // 请求被取消
+```
+
+## 性能考量
+
+1. **HTTP/2 Session 复用**：`http.js` 中 `Http2Sessions` 类缓存 Session，避免重复建连
+2. **流式响应**：大文件下载使用 `stream.Readable`，避免内存峰值
+3. **Zlib 解压**：自动处理 `gzip/br` 压缩响应，需考虑 CPU vs 带宽权衡
+4. **FormData 边界**：自动检测 `FormData` 类型，使用 `formDataToStream` 避免内存拷贝
+
+## 总结
+
+Axios 适配器模式的核心价值：
+
+1. **环境抽象**：一套 API，多端运行（浏览器/Node/小程序/React Native）
+2. **可替换性**：通过 `config.adapter` 或 `axios.defaults.adapter` 注入自定义实现
+3. **可测试性**：Mock 适配器让测试无需真实网络
+4. **功能扩展**：重试、降级、调试拦截等横切关注点
+
+理解适配器接口（`config → Promise<Response>`）是深度掌握 Axios 的关键。

--- a/docs/ssl/certificate-issues.md
+++ b/docs/ssl/certificate-issues.md
@@ -1,0 +1,372 @@
+# SSL/TLS 证书问题排查指南
+
+## 概述
+
+当浏览器访问 HTTPS 网站时，会验证证书链的每个环节。任何一环出问题都会导致安全警告甚至连接拒绝。本文系统梳理常见的证书问题类型、浏览器表现、排查方法和解决方案。
+
+---
+
+## 一、证书问题类型
+
+### 1. 证书本身过期（Certificate Expired）
+
+**原理：** SSL 证书有有效期的起始和截止日期（Not Before / Not After），浏览器会检查当前时间是否在此范围内。
+
+```
+证书有效期：
+[ Not Before ] ======= 当前时间 ======= [ Not After ]
+      └─────────────────────┘
+             ✓ 有效
+
+[ Not Before ] ======= [ Not After ] ======= 当前时间 ]
+      └─────────────────────┘
+                      └──────── × 过期
+```
+
+**典型场景：**
+- 运维忘记续期证书
+- 错误的系统时间导致"被过期"
+- 证书申请过早，上线时已接近过期
+
+### 2. 证书链不完整（Incomplete Certificate Chain）
+
+**原理：** 浏览器验证证书时需要从终端实体证书一路验到根 CA。服务器必须提供完整的中间证书链，否则浏览器无法追溯到受信任的根 CA。
+
+```
+完整证书链：
+┌─────────────────────┐
+│   根证书 (Root CA)   │  ← 浏览器内置，受操作系统信任
+└──────────┬──────────┘
+           │ 签名
+           ▼
+┌─────────────────────┐
+│  中间证书 (Intermediate) │  ← 可能有多级中间 CA
+└──────────┬──────────┘
+           │ 签名
+           ▼
+┌─────────────────────┐
+│  终端实体证书 (Server) │  ← 服务器配置的证书
+└─────────────────────┘
+
+不完整时：
+服务器只发送了终端证书 → 浏览器找不到中间证书 → 无法验证到根 → 不安全
+```
+
+**典型场景：**
+- Nginx/Apache 只配置了 `fullchain.pem`，实际发送的是纯实体证书
+- 反向代理（Nginx、HAProxy）没有正确传递证书链
+- 使用了新的 ACME 渠道签发的证书，中间 CA 较新，浏览器不熟悉
+
+### 3. 域名不匹配（Domain Mismatch）
+
+**原理：** 证书的 Subject Alternative Name (SAN) 或 Common Name (CN) 必须覆盖当前访问的域名。
+
+```
+证书CN=SAN: example.com
+访问 https://example.com       → ✓ 通过
+访问 https://www.example.com   → × SAN 不包含 www
+访问 https://api.example.com   → × SAN 不包含 api
+```
+
+**典型场景：**
+- 申请证书时只填了 `example.com`，但实际也用 `www.example.com` 访问
+- 通配符证书 `*.example.com` 不覆盖多级子域名 `sub.www.example.com`
+- 证书申请时的域名和实际访问的 IP/域名不一致
+- 测试环境使用生产域名的证书
+
+### 4. 自签名证书（Self-Signed Certificate）
+
+**原理：** 自签名证书没有经过受信任 CA 的签名，其根证书不在浏览器信任列表中。
+
+```
+自签名：
+┌─────────────────────┐
+│  自签名证书 (自己签自己) │
+└─────────────────────┘
+          ↓
+浏览器查找根 CA → 找不到 → 不信任
+
+正规 CA：
+证书由受信任根 CA 签发 → 根 CA 在浏览器信任列表 → 信任
+```
+
+**典型场景：**
+- 开发/测试环境使用 OpenSSL 自签证书
+- 内网系统使用私有 CA 签发的证书，但未导入根证书
+- 某些 IoT 设备使用硬编码的自签名证书
+
+### 5. 根证书过期（Root CA Expired）
+
+**原理：** 证书链顶端的根证书本身有过期时间（通常 20-30 年）。如果根 CA 过期，所有由它签发的证书都会失效，即使中间证书和终端证书本身未过期。
+
+```
+根 CA 过期时间线：
+根 CA 有效期：2010-01-01 ~ 2030-01-01
+中间 CA 有效期：2020-01-01 ~ 2040-01-01   ← 中间 CA 还在有效期内
+终端证书有效期：2024-01-01 ~ 2025-01-01  ← 终端证书也在有效期内
+
+但访问时：
+浏览器检查根 CA → 根 CA 已过期 → 整条链无效 → 报错
+```
+
+**典型场景：**
+- 老旧设备的内置根证书已过期（如某些嵌入式设备）
+- 企业私有 CA 的根证书过期后未及时更新
+- 某些老版本 Windows XP/IE6 系统
+
+### 6. 混合内容问题（Mixed Content）
+
+**原理：** HTTPS 页面加载了 HTTP 协议的资源（图片、脚本、样式表），浏览器会报"混合内容"警告。
+
+```
+https://example.com
+  ├── <script src="https://cdn.example.com/app.js">  ✓ 安全
+  └── <script src="http://cdn.example.com/app.js">  ✗ 混合内容
+```
+
+---
+
+## 二、浏览器提示场景对照表
+
+| 错误类型 | Chrome 提示 | Firefox 提示 | Safari 提示 | Edge 提示 |
+|---------|------------|-------------|------------|-----------|
+| 证书过期 | "此连接不是私密连接" / "ERR_CERT_EXPIRED" | "警告：前方有安全隐患" | "此连接不是专用" | 同 Chrome |
+| 证书链不完整 | "ERR_CERT_AUTHORITY_INVALID" | "sec_error_unknown_issuer" | "此证书无效" | 同 Chrome |
+| 域名不匹配 | "ERR_CERT_COMMON_NAME_INVALID" | "ssl_error_bad_cert_domain" | "Safari 无法验证网站身份" | 同 Chrome |
+| 自签名证书 | "ERR_CERT_AUTHORITY_INVALID" | "sec_error_untrusted_issuer" | "此证书无效" | 同 Chrome |
+| 根证书过期 | "ERR_CERT_PATH_EXCEEDS_LENGTH" 或 "CERT_HAS_EXPIRED" | "untrusted_cert_authority" | "此证书不受信任" | 同 Chrome |
+| 混合内容 | 控制台警告，不完全阻止 | 控制台警告 | 控制台警告 | 同 Chrome |
+
+---
+
+## 三、排查方法
+
+### 1. OpenSSL 命令行排查
+
+#### 查看证书详情
+```bash
+# 查看证书的所有信息
+openssl x509 -in server.crt -noout -text
+
+# 查看证书有效期
+openssl x509 -in server.crt -noout -dates
+
+# 查看证书支持的域名
+openssl x509 -in server.crt -noout -ext subjectAltName
+
+# 查看证书的颁发者
+openssl x509 -in server.crt -noout -issuer
+```
+
+#### 检查证书链
+```bash
+# 模拟浏览器验证证书链（连接到服务器）
+openssl s_client -connect example.com:443 -showcerts
+
+# 只显示证书链
+openssl s_client -connect example.com:443 -showcerts 2>/dev/null | openssl x509 -noout -text
+
+# 检查完整的证书链（包括中间证书）
+openssl s_client -connect example.com:443 -partial_chain -showcerts
+```
+
+#### 检查私钥匹配
+```bash
+# 查看私钥的 MD5 指纹
+openssl pkey -in privkey.pem -pubout -outform der | openssl md5
+
+# 查看证书的 MD5 指纹
+openssl x509 -in cert.pem -pubkey -noout | openssl pkey -pubout -outform der | openssl md5
+
+# 两个 MD5 值相同则匹配
+```
+
+#### 验证证书链完整性
+```bash
+# 将证书链合并（服务器证书在前，中间证书在后）
+cat server.crt intermediate.crt root.crt > chain.pem
+
+# 验证证书链
+openssl verify -CAfile root.crt -untrusted intermediate.crt server.crt
+```
+
+### 2. Chrome DevTools 排查
+
+#### Security 面板
+1. 打开 DevTools（F12）
+2. 切换到 **Security** 标签
+3. 查看证书信息：
+   - 证书有效性
+   - 证书链完整性
+   - 具体哪一级证书出问题
+
+#### 查看证书详情
+1. 点击锁图标 🔒 → "连接不安全" → "详细信息"
+2. 或直接访问 `chrome://cert-internals`
+
+#### 查看证书链
+```
+DevTools → Security → View certificate → 证书路径（查看每一级状态）
+```
+
+#### Console 面板混合内容警告
+```
+DevTools → Console → 搜索 "Mixed Content" 或 "mixed-content"
+```
+
+### 3. 在线工具
+
+| 工具 | 地址 | 用途 |
+|------|------|------|
+| SSL Labs | https://www.ssllabs.com/ssltest/ | 全面 SSL 配置检测 |
+| SSL Shopper | https://www.sslshopper.com/ssl-checker.html | 证书链检查 |
+| Let's Encrypt | https://letsencrypt.org/certificates/ | 查看中间 CA |
+| Chrome Certificate Viewer | chrome://cert-internals | 查看内置根 CA |
+
+---
+
+## 四、常见设备/浏览器兼容性说明
+
+### 根证书兼容性
+
+| 设备/浏览器 | 内置根 CA 库 | 更新频率 | 备注 |
+|-----------|-------------|---------|------|
+| Windows 10/11 | Windows Update | 自动 | 企业环境可通过 AD 推送 |
+| macOS | Apple Root CA Program | 系统更新 | Safari 定期同步 |
+| iOS | Apple Root CA Program | 系统更新 | 某些根 CA 需要用户手动信任 |
+| Android | 设备厂商 | 不一致 | 老设备可能缺少新根 CA |
+| Chrome (Linux) | Mozilla NSS | 定期更新 | 与 Firefox 共享同一套根 CA |
+| Firefox | 自己的根 CA 列表 | 6-8 周 | 独立于系统和 Chrome |
+| Java (JDK) | `cacerts` keystore | 随 JDK 更新 | 默认密码 `changeit` |
+
+### Let's Encrypt 证书兼容性
+
+Let's Encrypt 使用的是 **ISRG Root X1** 和 **ISRG Root X2** 根证书：
+
+| 客户端/设备 | ISRG Root X1 支持 | ISRG Root X2 支持 | 备注 |
+|-----------|-----------------|-----------------|------|
+| Android 7.1+ | ✓ | ✗ | 7.1 以下需要 DST Root CA X3 |
+| Firefox (所有版本) | ✓ | ✓ | 内置自己的根 CA 列表 |
+| Chrome (Win/Mac) | ✓ | ✓ | 依赖系统根 CA |
+| Java 11+ | ✓ | 部分 | 某些旧 JDK 版本有问题 |
+| OpenSSL 1.1.1+ | ✓ | ✓ | |
+
+### 证书签名算法兼容性
+
+| 算法 | 兼容性 | 说明 |
+|------|--------|------|
+| SHA-1 with RSA | ❌ 已废弃 | 2020 年起所有浏览器拒绝 |
+| SHA-256 with RSA | ✓ 通用 | 最低要求 |
+| SHA-384 with RSA | ✓ 通用 | 推荐用于金融等高安全场景 |
+| ECDSA P-256 | ✓ 现代 | 更小、更快，逐渐成为主流 |
+| ECDSA P-384 | ✓ 现代 | 高安全要求场景 |
+
+### 密钥长度要求
+
+| 算法 | 密钥长度 | 兼容性 |
+|------|---------|--------|
+| RSA | 2048-bit | ✓ 最低要求 |
+| RSA | 4096-bit | ⚠ 老旧设备可能不支持 |
+| ECDSA | P-256 | ✓ 现代通用 |
+| ECDSA | P-384 | ✓ 高安全场景 |
+
+---
+
+## 五、解决方案
+
+### 证书过期 → 续期
+```bash
+# 使用 acme.sh 续期
+acme.sh --renew -d example.com
+
+# 使用 certbot 续期
+certbot renew
+
+# 手动替换证书后重载 Nginx
+nginx -s reload
+```
+
+### 证书链不完整 → 拼接中间证书
+```bash
+# 查看服务器发送的证书链
+openssl s_client -connect example.com:443 -showcerts
+
+# 下载中间证书（以 Let's Encrypt 为例）
+curl -sS https://letsencrypt.org/certs/isrgrootx1.pem > root.pem
+curl -sS https://letsencrypt.org/certs/letsencryptAuthorityX3.pem > intermediate.pem
+
+# 合并证书链（服务器证书在前，中间证书在后）
+cat /etc/ssl/certs/example.com.crt /etc/ssl/certs/intermediate.pem > /etc/ssl/certs/fullchain.pem
+
+# Nginx 配置
+ssl_certificate /etc/ssl/certs/fullchain.pem;  # 不是 server.crt
+ssl_certificate_key /etc/ssl/private/example.com.key;
+```
+
+### 域名不匹配 → 重新申请或添加 SAN
+```bash
+# 通配符证书覆盖所有子域名
+certbot -d "example.com" -d "*.example.com"
+
+# 多域名证书
+certbot -d "example.com" -d "www.example.com" -d "api.example.com"
+```
+
+### 自签名证书 → 开发环境使用
+```bash
+# 生成自签名证书（仅测试用）
+openssl req -x509 -newkey rsa:2048 -keyout key.pem -out cert.pem -days 365 -nodes \
+  -subj "/CN=localhost"
+
+# 将根证书导入系统信任库（仅内网）
+# macOS
+sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain ca.crt
+
+# Linux (Ubuntu/Debian)
+sudo cp ca.crt /usr/local/share/ca-certificates/
+sudo update-ca-certificates
+```
+
+### 根证书过期 → 更新根证书
+```bash
+# 浏览器自动更新（大多数情况）
+# 企业环境：更新内部 CA
+
+# 检查系统根证书过期时间
+openssl x509 -in /etc/ssl/certs/ca-certificates.crt -noout -dates
+```
+
+---
+
+## 六、实战排查流程
+
+```
+遇到证书错误？
+  │
+  ├─ 1. 确认错误类型
+  │     Chrome DevTools → Security 面板
+  │
+  ├─ 2. 查看证书详情
+  │     锁图标 → "证书信息" → 有效期、域名、颁发者
+  │
+  ├─ 3. 检查证书链
+  │     Security 面板 → 证书路径 → 哪一级有问题？
+  │
+  ├─ 4. 本地验证
+  │     openssl s_client -connect example.com:443 -showcerts
+  │
+  └─ 5. 针对性修复
+        过期 → 续期
+        链不完整 → 补全中间证书
+        域名不匹配 → 重新申请
+        自签名 → 导入根证书或更换证书
+```
+
+---
+
+## 七、相关资源
+
+- [Mozilla SSL Configuration Generator](https://ssl-config.mozilla.org/)
+- [SSL Labs Server Test](https://www.ssllabs.com/ssltest/)
+- [Let's Encrypt 证书链说明](https://letsencrypt.org/certificates/)
+- [Chrome 根证书存储](https://.chromium.googlesource.com/chromium/src/+/main/net/data/ssl/symantec_certs/)

--- a/examples/axios/axios-adapter-demo.html
+++ b/examples/axios/axios-adapter-demo.html
@@ -1,0 +1,373 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Axios Adapter 交互式演示</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background: #0f0f23; color: #e4e4e7; padding: 24px; min-height: 100vh; }
+    h1 { font-size: 1.5rem; margin-bottom: 8px; color: #fff; }
+    .subtitle { color: #71717a; margin-bottom: 24px; font-size: 0.9rem; }
+    .tabs { display: flex; gap: 4px; margin-bottom: 16px; }
+    .tab { padding: 8px 16px; background: #1e1e2e; border: none; color: #71717a; cursor: pointer; border-radius: 6px 6px 0 0; font-size: 0.875rem; transition: all 0.2s; }
+    .tab:hover { color: #a1a1aa; }
+    .tab.active { background: #18181b; color: #fff; }
+    .panel { background: #18181b; border-radius: 0 8px 8px 8px; padding: 20px; }
+    .panel-section { margin-bottom: 20px; }
+    .panel-section h3 { font-size: 0.875rem; color: #a1a1aa; margin-bottom: 8px; text-transform: uppercase; letter-spacing: 0.05em; }
+    .code-block { background: #0f0f23; border-radius: 6px; padding: 16px; font-family: 'Monaco', 'Menlo', monospace; font-size: 0.8rem; overflow-x: auto; white-space: pre; line-height: 1.6; }
+    .code-block .keyword { color: #c678dd; }
+    .code-block .string { color: #98c379; }
+    .code-block .comment { color: #5c6370; font-style: italic; }
+    .code-block .function { color: #61afef; }
+    .code-block .number { color: #d19a66; }
+    .code-block .param { color: #e06c75; }
+    .btn { padding: 10px 20px; background: #4f46e5; color: #fff; border: none; border-radius: 6px; cursor: pointer; font-size: 0.875rem; transition: all 0.2s; }
+    .btn:hover { background: #4338ca; }
+    .btn:disabled { opacity: 0.5; cursor: not-allowed; }
+    .output { background: #0f0f23; border-radius: 6px; padding: 16px; margin-top: 16px; min-height: 80px; font-family: 'Monaco', 'Menlo', monospace; font-size: 0.8rem; max-height: 300px; overflow-y: auto; }
+    .output .success { color: #98c379; }
+    .output .error { color: #e06c75; }
+    .output .info { color: #61afef; }
+    .grid-2 { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+    @media (max-width: 768px) { .grid-2 { grid-template-columns: 1fr; } }
+    .arrow-diagram { display: flex; align-items: center; justify-content: center; gap: 16px; padding: 24px; background: #0f0f23; border-radius: 8px; margin: 16px 0; flex-wrap: wrap; }
+    .arrow-step { display: flex; flex-direction: column; align-items: center; gap: 8px; }
+    .arrow-box { background: #27272a; padding: 12px 20px; border-radius: 8px; text-align: center; min-width: 120px; }
+    .arrow-box.primary { background: #4f46e5; }
+    .arrow-box.secondary { background: #27272a; border: 1px solid #3f3f46; }
+    .arrow-arrow { color: #52525b; font-size: 1.5rem; }
+    .comparison-table { width: 100%; border-collapse: collapse; margin-top: 16px; }
+    .comparison-table th, .comparison-table td { padding: 12px; text-align: left; border-bottom: 1px solid #27272a; font-size: 0.875rem; }
+    .comparison-table th { color: #71717a; font-weight: 500; text-transform: uppercase; font-size: 0.75rem; letter-spacing: 0.05em; }
+    .comparison-table td:first-child { color: #a1a1aa; }
+    .tag { display: inline-block; padding: 2px 8px; background: #27272a; border-radius: 4px; font-size: 0.75rem; color: #a1a1aa; margin-right: 4px; }
+    .tag.xhr { background: #1e3a5f; color: #60a5fa; }
+    .tag.http { background: #1e3a2f; color: #34d399; }
+    .tag.mock { background: #3b1e5f; color: #a78bfa; }
+    .flow-step { background: #1e1e2e; border-radius: 6px; padding: 16px; margin-bottom: 12px; border-left: 3px solid #4f46e5; }
+    .flow-step h4 { font-size: 0.875rem; margin-bottom: 8px; color: #fff; }
+    .flow-step p { font-size: 0.8rem; color: #71717a; line-height: 1.5; }
+    .input-group { margin-bottom: 12px; }
+    .input-group label { display: block; font-size: 0.75rem; color: #71717a; margin-bottom: 4px; }
+    .input-group input, .input-group select { width: 100%; padding: 8px 12px; background: #0f0f23; border: 1px solid #27272a; border-radius: 6px; color: #e4e4e7; font-size: 0.875rem; }
+    .input-group input:focus, .input-group select:focus { outline: none; border-color: #4f46e5; }
+  </style>
+</head>
+<body>
+  <h1>Axios Adapter 适配器模式</h1>
+  <p class="subtitle">理解 Axios 如何通过适配器接口实现跨环境 HTTP 请求</p>
+
+  <div class="tabs">
+    <button class="tab active" data-tab="pattern">适配器接口</button>
+    <button class="tab" data-tab="flow">请求流程</button>
+    <button class="tab" data-tab="custom">自定义适配器</button>
+    <button class="tab" data-tab="compare">方案对比</button>
+  </div>
+
+  <div class="panel">
+    <!-- 适配器接口 -->
+    <div id="panel-pattern" class="tab-content">
+      <div class="panel-section">
+        <h3>Adapter 接口定义</h3>
+        <div class="code-block"><span class="comment">// Axios 适配器接口 — 接收 config，返回 Promise</span>
+<span class="keyword">function</span> <span class="function">adapter</span>(<span class="param">config</span>) {
+  <span class="comment">// config 已完成合并、转换器、拦截器预处理</span>
+  <span class="comment">// 返回 Promise，resolve 时触发 response 转换器</span>
+  <span class="keyword">return</span> <span class="keyword">new</span> Promise(<span class="keyword">function</span>(<span class="param">resolve, reject</span>) {
+    <span class="comment">// 执行实际请求...</span>
+    <span class="keyword">const</span> response = {
+      data:       <span class="string">responseData</span>,
+      status:     <span class="param">request</span>.status,
+      statusText: <span class="param">request</span>.statusText,
+      headers:    <span class="param">responseHeaders</span>,
+      config:     <span class="param">config</span>,
+      request:    <span class="param">request</span>
+    };
+    <span class="comment">// settle 决定 resolve 或 reject</span>
+    settle(resolve, reject, response);
+  });
+}</div>
+      </div>
+
+      <div class="panel-section">
+        <h3>内置适配器映射</h3>
+        <div class="arrow-diagram">
+          <div class="arrow-step">
+            <div class="arrow-box primary">Axios(config)</div>
+            <span style="font-size:0.75rem;color:#71717a">发起请求</span>
+          </div>
+          <span class="arrow-arrow">→</span>
+          <div class="arrow-step">
+            <div class="arrow-box secondary">dispatchRequest</div>
+            <span style="font-size:0.75rem;color:#71717a">调度适配器</span>
+          </div>
+          <span class="arrow-arrow">→</span>
+          <div class="arrow-step">
+            <div class="arrow-box secondary">getAdapter()</div>
+            <span style="font-size:0.75rem;color:#71717a">选择适配器</span>
+          </div>
+          <span class="arrow-arrow">→</span>
+          <div class="arrow-step">
+            <div class="arrow-box secondary">adapter(config)</div>
+            <span style="font-size:0.75rem;color:#71717a">执行请求</span>
+          </div>
+        </div>
+        <div class="comparison-table">
+          <table>
+            <thead>
+              <tr><th>适配器</th><th>环境</th><th>实现</th><th>关键特性</th></tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td><span class="tag xhr">xhr</span></td>
+                <td>浏览器</td>
+                <td>XMLHttpRequest</td>
+                <td>上传/下载进度、请求取消、Cookie</td>
+              </tr>
+              <tr>
+                <td><span class="tag http">http</span></td>
+                <td>Node.js</td>
+                <td>http/https 模块</td>
+                <td>重定向、代理、HTTP/2、流式响应</td>
+              </tr>
+              <tr>
+                <td><span class="tag mock">mock</span></td>
+                <td>测试/开发</td>
+                <td>自定义</td>
+                <td>无网络延迟、可模拟错误</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+
+    <!-- 请求流程 -->
+    <div id="panel-flow" class="tab-content" style="display:none;">
+      <div class="panel-section">
+        <h3>XHR Adapter 请求流程（浏览器环境）</h3>
+        <div class="flow-step">
+          <h4>1. dispatchRequest(config)</h4>
+          <p>Axios 核心模块，合并默认配置与应用配置，运行请求转换器。</p>
+        </div>
+        <div class="flow-step">
+          <h4>2. getAdapter() 选择适配器</h4>
+          <p>根据环境判断：浏览器 → xhrAdapter，Node → httpAdapter。可通过 config.adapter 手动指定。</p>
+        </div>
+        <div class="flow-step">
+          <h4>3. xhrAdapter(config) 创建 Promise</h4>
+          <p>返回 Promise，异步执行 XMLHttpRequest。</p>
+        </div>
+        <div class="flow-step">
+          <h4>4. XMLHttpRequest.open()</h4>
+          <p>request.open(method, url, async) 建立连接。</p>
+        </div>
+        <div class="flow-step">
+          <h4>5. 设置请求头与选项</h4>
+          <p>setRequestHeader 设置自定义头，withCredentials 处理跨域 Cookie，responseType 指定响应格式。</p>
+        </div>
+        <div class="flow-step">
+          <h4>6. 注册事件处理器</h4>
+          <p>onloadend / onreadystatechange：响应完成；onabort：取消；onerror：网络错误；ontimeout：超时。</p>
+        </div>
+        <div class="flow-step">
+          <h4>7. request.send(data)</h4>
+          <p>发送请求，data 为请求体（FormData / JSON / 二进制）。</p>
+        </div>
+        <div class="flow-step">
+          <h4>8. settle(resolve, reject, response)</h4>
+          <p>根据 HTTP 状态码决定 Promise resolve 或 reject。2xx → resolve，其他 → reject。</p>
+        </div>
+        <div class="flow-step">
+          <h4>9. Response Interceptors</h4>
+          <p>响应拦截器处理 data 转换、错误标准化等。</p>
+        </div>
+      </div>
+
+      <div class="panel-section">
+        <h3>HTTP Adapter 请求流程（Node 环境）</h3>
+        <div class="flow-step">
+          <h4>1. buildFullPath() 构建完整路径</h4>
+          <p>合并 baseURL + url，处理绝对/相对路径。</p>
+        </div>
+        <div class="flow-step">
+          <h4>2. 数据流处理</h4>
+          <p>Buffer / ArrayBuffer / string → Buffer；FormData → stream；File/Blob → stream。</p>
+        </div>
+        <div class="flow-step">
+          <h4>3. http/https.request(options)</h4>
+          <p>创建 Node.js http(s) 请求，支持代理、重定向、超时。</p>
+        </div>
+        <div class="flow-step">
+          <h4>4. 进度与取消</h4>
+          <p>通过 EventEmitter 实现 abort 信号，可配合 AbortController 使用。</p>
+        </div>
+      </div>
+    </div>
+
+    <!-- 自定义适配器 -->
+    <div id="panel-custom" class="tab-content" style="display:none;">
+      <div class="grid-2">
+        <div class="panel-section">
+          <h3>自定义 Mock 适配器</h3>
+          <div class="code-block"><span class="comment">// mock-adapter.js — 模拟请求适配器</span>
+<span class="keyword">function</span> <span class="function">mockAdapter</span>(<span class="param">config</span>) {
+  <span class="keyword">return</span> <span class="keyword">new</span> Promise((<span class="param">resolve, reject</span>) => {
+    <span class="comment">// 模拟延迟</span>
+    setTimeout(() => {
+      <span class="keyword">const</span> response = {
+        data: { <span class="string">message</span>: <span class="string">'Mock 响应'</span>, config },
+        status: <span class="number">200</span>,
+        statusText: <span class="string">'OK'</span>,
+        headers: { <span class="string">'content-type'</span>: <span class="string">'application/json'</span> },
+        config,
+        request: <span class="keyword">null</span>
+      };
+      <span class="comment">// 模拟错误（config.forceError = true）</span>
+      <span class="keyword">if</span> (config.forceError) {
+        <span class="keyword">return</span> reject(<span class="keyword">new</span> Error(<span class="string">'Mock Error'</span>));
+      }
+      resolve(response);
+    }, config.delay || <span class="number">500</span>);
+  });
+}
+
+<span class="comment">// 使用方式</span>
+<span class="keyword">const</span> axios = <span class="function">require</span>(<span class="string">'axios'</span>);
+axios.defaults.adapter = mockAdapter;</div>
+        </div>
+      </div>
+
+      <div class="panel-section">
+        <h3>实际使用场景</h3>
+        <div class="comparison-table">
+          <table>
+            <thead>
+              <tr><th>场景</th><th>适配器实现</th><th>用途</th></tr>
+            </thead>
+            <tbody>
+              <tr><td>单元测试</td><td><span class="tag mock">Mock</span></td><td>无网络依赖，秒级完成</td></tr>
+              <tr><td>接口 Mock</td><td><span class="tag mock">Mock</span></td><td>前后端并行开发</td></tr>
+              <tr><td>跨端复用</td><td><span class="tag xhr">xhr</span></td><td>小程序/Uni-app 适配</td></tr>
+              <tr><td>调试代理</td><td><span class="tag xhr">xhr</span></td><td> Whistle / Charles 拦截</td></tr>
+              <tr><td>Service Worker</td><td><span class="tag http">http</span></td><td>离线缓存/网络优先</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div class="panel-section">
+        <h3>实战：自定义适配器实现请求重试</h3>
+        <div class="code-block"><span class="keyword">function</span> <span class="function">retryAdapter</span>(<span class="param">config</span>) {
+  <span class="keyword">const</span> maxRetries = config.retryCount || <span class="number">3</span>;
+  <span class="keyword">const</span> retryDelay = config.retryDelay || <span class="number">1000</span>;
+  <span class="keyword">const</span> originalAdapter = <span class="function">require</span>(<span class="string">'axios/lib/adapters/xhr'</span>);
+
+  <span class="keyword">function</span> <span class="function">attempt</span>(<span class="param">retryCount</span>) {
+    <span class="keyword">return</span> originalAdapter(config)
+      .catch(<span class="param">err</span> => {
+        <span class="keyword">if</span> (retryCount < maxRetries && isRetryableError(err)) {
+          <span class="keyword">return</span> <span class="keyword">new</span> Promise(<span class="function">resolve</span> => 
+            setTimeout(() => <span class="function">resolve</span>(<span class="function">attempt</span>(retryCount + <span class="number">1</span>)), retryDelay
+          ));
+        }
+        <span class="keyword">throw</span> err;
+      });
+  }
+
+  <span class="keyword">return</span> <span class="function">attempt</span>(<span class="number">0</span>);
+}
+
+<span class="comment">// 使用</span>
+axios.defaults.adapter = retryAdapter;</div>
+      </div>
+    </div>
+
+    <!-- 方案对比 -->
+    <div id="panel-compare" class="tab-content" style="display:none;">
+      <div class="panel-section">
+        <h3>Adapter vs Interceptor vs Transform</h3>
+        <div class="comparison-table">
+          <table>
+            <thead>
+              <tr><th>机制</th><th>作用层级</th><th>执行时机</th><th>适用场景</th></tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>Adapter</td>
+                <td>底层网络</td>
+                <td>最终请求发送</td>
+                <td>跨平台适配、Mock、调试拦截</td>
+              </tr>
+              <tr>
+                <td>Interceptor</td>
+                <td>请求/响应</td>
+                <td>请求前/响应后</td>
+                <td>统一 header、错误处理、日志</td>
+              </tr>
+              <tr>
+                <td>Transform</td>
+                <td>数据转换</td>
+                <td>请求序列化/响应反序列化</td>
+                <td>JSON 解析、格式转换</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div class="panel-section">
+        <h3>XHR vs Fetch vs http 模块</h3>
+        <div class="comparison-table">
+          <table>
+            <thead>
+              <tr><th>特性</th><th>XHR</th><th>Fetch</th><th>http 模块</th></tr>
+            </thead>
+            <tbody>
+              <tr><td>进度追踪</td><td><span class="success">✓ onprogress</span></td><td><span class="error">✗</span></td><td><span class="success">✓ stream</span></td></tr>
+              <tr><td>请求取消</td><td><span class="success">✓ abort</span></td><td><span class="success">✓ AbortController</span></td><td><span class="success">✓ destroy</span></td></tr>
+              <tr><td>超时控制</td><td><span class="success">✓ timeout</span></td><td><span class="error">需手写</span></td><td><span class="success">✓ setTimeout</span></td></tr>
+              <tr><td>跨域 Cookie</td><td><span class="success">✓ withCredentials</span></td><td><span class="success">✓ credentials</span></td><td><span class="error">N/A</span></td></tr>
+              <tr><td>代理支持</td><                <td><span class="error">需配置</span></td><td><span class="error">需手写</span></td><td><span class="success">✓ Agent</span></td></tr>
+              <tr><td>HTTP/2</td><td><span class="error">✗</span></td><td><span class="success">✓</span></td><td><span class="success">✓ http2</span></td></tr>
+              <tr><td>流式响应</td><td><span class="error">✗</span></td><td><span class="success">✓ ReadableStream</span></td><td><span class="success">✓ stream</span></td></tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div class="panel-section">
+        <h3>为什么需要适配器？</h3>
+        <div class="arrow-diagram" style="flex-direction:column;gap:8px;">
+          <div class="flow-step" style="margin:0;border-left-color:#4f46e5;">
+            <h4>同一套 API，多端运行</h4>
+            <p>Axios 代码可以在浏览器 (XMLHttpRequest)、Node.js (http 模块)、微信小程序、React Native 等环境运行，底层自动切换适配器。</p>
+          </div>
+          <div class="flow-step" style="margin:0;border-left-color:#4f46e5;">
+            <h4>可测试性</h4>
+            <p>通过 Mock 适配器，测试套件无需启动真实服务器，可模拟任意响应（成功/错误/超时）。</p>
+          </div>
+          <div class="flow-step" style="margin:0;border-left-color:#4f46e5;">
+            <h4>功能扩展</h4>
+            <p>请求重试、自动降级、调试拦截等横切关注点可通过自定义适配器统一注入。</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    // Tab switching
+    document.querySelectorAll('.tab').forEach(tab => {
+      tab.addEventListener('click', () => {
+        document.querySelectorAll('.tab').forEach(t => t.classList.remove('active'));
+        document.querySelectorAll('.tab-content').forEach(p => p.style.display = 'none');
+        tab.classList.add('active');
+        document.getElementById('panel-' + tab.dataset.tab).style.display = 'block';
+      });
+    });
+  </script>
+</body>
+</html>

--- a/examples/ssl/certificate-demo.html
+++ b/examples/ssl/certificate-demo.html
@@ -1,0 +1,550 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>SSL/TLS 证书问题交互演示</title>
+  <style>
+    :root {
+      --bg: #0a0a0f;
+      --surface: #13131f;
+      --border: #1e1e2e;
+      --accent: #00d4aa;
+      --accent2: #7c3aed;
+      --text: #e4e4e7;
+      --text-muted: #71717a;
+      --green: #22c55e;
+      --red: #ef4444;
+      --yellow: #f59e0b;
+      --radius: 12px;
+    }
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      background: var(--bg);
+      color: var(--text);
+      font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace;
+      min-height: 100vh;
+      padding: 2rem;
+      line-height: 1.6;
+    }
+    h1 {
+      font-size: 1.8rem;
+      font-weight: 700;
+      background: linear-gradient(135deg, var(--accent), var(--accent2));
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      margin-bottom: 0.5rem;
+    }
+    .subtitle { color: var(--text-muted); font-size: 0.875rem; margin-bottom: 2rem; }
+    .tabs {
+      display: flex;
+      gap: 0.25rem;
+      margin-bottom: 1.5rem;
+      flex-wrap: wrap;
+      background: var(--surface);
+      padding: 0.25rem;
+      border-radius: var(--radius);
+      border: 1px solid var(--border);
+    }
+    .tab {
+      padding: 0.5rem 1rem;
+      border: none;
+      background: transparent;
+      color: var(--text-muted);
+      cursor: pointer;
+      border-radius: 8px;
+      font-family: inherit;
+      font-size: 0.8rem;
+      transition: all 0.2s;
+    }
+    .tab:hover { color: var(--text); background: var(--border); }
+    .tab.active { background: var(--accent); color: #000; font-weight: 600; }
+    .tab-content { display: none; }
+    .tab-content.active { display: block; }
+    .card {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      padding: 1.5rem;
+      margin-bottom: 1rem;
+    }
+    .card-title {
+      font-size: 0.75rem;
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      color: var(--accent);
+      margin-bottom: 1rem;
+    }
+    .chain-container {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 0;
+      margin: 1.5rem 0;
+    }
+    .chain-node {
+      display: flex;
+      align-items: center;
+      gap: 1rem;
+      padding: 0.75rem 1.25rem;
+      border-radius: var(--radius);
+      border: 2px solid;
+      width: 100%;
+      max-width: 520px;
+      position: relative;
+      transition: all 0.3s;
+    }
+    .chain-node.root { border-color: var(--accent2); background: rgba(124,58,237,0.1); }
+    .chain-node.intermediate { border-color: var(--yellow); background: rgba(245,158,11,0.1); }
+    .chain-node.server { border-color: var(--accent); background: rgba(0,212,170,0.1); }
+    .chain-node.error { border-color: var(--red); background: rgba(239,68,68,0.1); }
+    .chain-node.valid { border-color: var(--green); background: rgba(34,197,94,0.1); }
+    .chain-node-label {
+      font-size: 0.7rem;
+      color: var(--text-muted);
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      position: absolute;
+      top: -0.5rem;
+      left: 1rem;
+      background: var(--bg);
+      padding: 0 0.5rem;
+    }
+    .chain-node-icon { font-size: 1.5rem; flex-shrink: 0; }
+    .chain-node-info { flex: 1; }
+    .chain-node-name { font-weight: 600; font-size: 0.9rem; }
+    .chain-node-detail { font-size: 0.75rem; color: var(--text-muted); margin-top: 0.15rem; }
+    .chain-arrow { font-size: 1.2rem; color: var(--text-muted); padding: 0.25rem 0; }
+    .status-badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.35rem;
+      padding: 0.2rem 0.6rem;
+      border-radius: 20px;
+      font-size: 0.7rem;
+      font-weight: 600;
+      flex-shrink: 0;
+    }
+    .status-badge.ok { background: rgba(34,197,94,0.2); color: var(--green); }
+    .status-badge.error { background: rgba(239,68,68,0.2); color: var(--red); }
+    .status-badge.warn { background: rgba(245,158,11,0.2); color: var(--yellow); }
+    .selector-group { display: flex; gap: 0.5rem; flex-wrap: wrap; margin-bottom: 1rem; }
+    .selector-btn {
+      padding: 0.4rem 0.85rem;
+      border: 1px solid var(--border);
+      background: transparent;
+      color: var(--text);
+      border-radius: 6px;
+      cursor: pointer;
+      font-family: inherit;
+      font-size: 0.8rem;
+      transition: all 0.2s;
+    }
+    .selector-btn:hover { border-color: var(--accent); }
+    .selector-btn.active { background: var(--accent); color: #000; border-color: var(--accent); }
+    table { width: 100%; border-collapse: collapse; font-size: 0.8rem; margin-top: 1rem; }
+    th {
+      text-align: left;
+      color: var(--accent);
+      padding: 0.5rem 0.75rem;
+      border-bottom: 1px solid var(--border);
+      font-size: 0.7rem;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+    }
+    td { padding: 0.5rem 0.75rem; border-bottom: 1px solid var(--border); vertical-align: top; }
+    tr:last-child td { border-bottom: none; }
+    td code { color: var(--yellow); }
+    .cmd-block {
+      background: #000;
+      border-radius: 8px;
+      padding: 1rem;
+      margin: 0.75rem 0;
+      overflow-x: auto;
+    }
+    .cmd-title { color: var(--text); font-size: 0.85rem; margin-bottom: 0.5rem; font-weight: 600; }
+    .cmd-prompt { color: var(--accent); }
+    .cmd-cmd { color: var(--text); font-size: 0.82rem; margin-bottom: 0.25rem; word-break: break-all; }
+    .cmd-out { color: var(--green); font-size: 0.78rem; white-space: pre-wrap; word-break: break-all; }
+    .browser-sim {
+      background: rgba(239,68,68,0.06);
+      border: 1px solid rgba(239,68,68,0.2);
+      border-radius: var(--radius);
+      overflow: hidden;
+    }
+    .browser-sim-header {
+      background: #1a1a2e;
+      padding: 0.5rem 0.75rem;
+      display: flex;
+      gap: 0.5rem;
+      align-items: center;
+    }
+    .browser-sim-dot { width: 10px; height: 10px; border-radius: 50%; flex-shrink: 0; }
+    .browser-sim-body { padding: 2rem; text-align: center; }
+    .browser-sim-body .icon { font-size: 3rem; margin-bottom: 1rem; }
+    .browser-sim-body h3 { color: var(--text); font-size: 1rem; margin-bottom: 0.5rem; }
+    .browser-sim-body p { color: var(--text-muted); font-size: 0.8rem; margin-bottom: 0.75rem; }
+    .browser-sim-error {
+      background: rgba(239,68,68,0.12);
+      border: 1px solid rgba(239,68,68,0.3);
+      border-radius: 8px;
+      padding: 0.5rem 1rem;
+      display: inline-block;
+      color: var(--red);
+      font-size: 0.8rem;
+      font-weight: 600;
+    }
+    .tree { font-size: 0.85rem; color: var(--text-muted); line-height: 2.2; }
+    .tree strong { color: var(--text); }
+    .tree a { color: var(--accent); }
+    .footer {
+      margin-top: 2rem;
+      padding-top: 1rem;
+      border-top: 1px solid var(--border);
+      font-size: 0.75rem;
+      color: var(--text-muted);
+      text-align: center;
+    }
+    @keyframes pulse-error {
+      0%, 100% { box-shadow: 0 0 0 0 rgba(239,68,68,0.4); }
+      50% { box-shadow: 0 0 0 8px rgba(239,68,68,0); }
+    }
+    .pulse-error { animation: pulse-error 1.5s infinite; }
+  </style>
+</head>
+<body>
+
+<h1>SSL/TLS 证书问题交互演示</h1>
+<p class="subtitle">learn-network / examples / ssl / certificate-demo.html</p>
+
+<div class="tabs">
+  <button class="tab active" data-tab="chain">证书链结构</button>
+  <button class="tab" data-tab="browser">浏览器提示</button>
+  <button class="tab" data-tab="openssl">OpenSSL 排查</button>
+  <button class="tab" data-tab="compat">兼容性</button>
+  <button class="tab" data-tab="troubleshoot">排查流程</button>
+</div>
+
+<!-- Tab: Chain -->
+<div id="tab-chain" class="tab-content active">
+  <div class="card">
+    <div class="card-title">选择证书问题类型</div>
+    <div class="selector-group" id="chain-selector">
+      <button class="selector-btn active" data-type="valid">完整有效链</button>
+      <button class="selector-btn" data-type="expired">证书过期</button>
+      <button class="selector-btn" data-type="incomplete">链不完整</button>
+      <button class="selector-btn" data-type="mismatch">域名不匹配</button>
+      <button class="selector-btn" data-type="selfsigned">自签名证书</button>
+      <button class="selector-btn" data-type="root-expired">根证书过期</button>
+    </div>
+  </div>
+  <div id="chain-display"></div>
+  <div class="card">
+    <div class="card-title">说明</div>
+    <p style="color: var(--text-muted); font-size: 0.85rem;" id="explanation-text">选择不同的场景，查看对应的证书链状态和浏览器行为。</p>
+  </div>
+</div>
+
+<!-- Tab: Browser -->
+<div id="tab-browser" class="tab-content">
+  <div class="card">
+    <div class="card-title">浏览器错误提示对照表</div>
+    <table>
+      <thead>
+        <tr><th>问题类型</th><th>Chrome / Edge</th><th>Firefox</th><th>Safari</th></tr>
+      </thead>
+      <tbody>
+        <tr><td>证书本身过期</td><td><code>ERR_CERT_EXPIRED</code></td><td><code>MOZILLA_PKIX_ERROR_CERT_EXPIRED</code></td><td>"证书已过期"</td></tr>
+        <tr><td>证书链不完整</td><td><code>ERR_CERT_AUTHORITY_INVALID</code></td><td><code>SEC_ERROR_UNKNOWN_ISSUER</code></td><td>"无法验证网站身份"</td></tr>
+        <tr><td>域名不匹配</td><td><code>ERR_CERT_COMMON_NAME_INVALID</code></td><td><code>SSL_ERROR_BAD_CERT_DOMAIN</code></td><td>"Safari 无法验证网站身份"</td></tr>
+        <tr><td>自签名证书</td><td><code>ERR_CERT_AUTHORITY_INVALID</code></td><td><code>SEC_ERROR_UNTRUSTED_ISSUER</code></td><td>"此证书不受信任"</td></tr>
+        <tr><td>根证书过期</td><td><code>CERT_HAS_EXPIRED</code></td><td><code>MOZILLA_PKIX_ERROR_PATH_LEN_EXCEEDED</code></td><td>"证书链无效"</td></tr>
+      </tbody>
+    </table>
+  </div>
+  <div class="card">
+    <div class="card-title">模拟浏览器错误界面（点击上方「证书链结构」中的场景）</div>
+    <div id="browser-sim-panel">
+      <p style="color: var(--text-muted); font-size: 0.85rem;">在上方选择有问题的场景，查看对应的模拟错误界面。</p>
+    </div>
+  </div>
+</div>
+
+<!-- Tab: OpenSSL -->
+<div id="tab-openssl" class="tab-content">
+  <div class="selector-group" id="cmd-selector">
+    <button class="selector-btn active" data-cmd="info">查看证书信息</button>
+    <button class="selector-btn" data-cmd="chain">检查证书链</button>
+    <button class="selector-btn" data-cmd="verify">验证证书</button>
+    <button class="selector-btn" data-cmd="match">匹配私钥</button>
+  </div>
+  <div id="cmd-display"></div>
+</div>
+
+<!-- Tab: Compatibility -->
+<div id="tab-compat" class="tab-content">
+  <div class="card">
+    <div class="card-title">Let's Encrypt 根 CA 兼容性</div>
+    <table>
+      <thead><tr><th>设备 / 平台</th><th>ISRG Root X1</th><th>ISRG Root X2</th><th>备注</th></tr></thead>
+      <tbody>
+        <tr><td>Android 7.1+</td><td><span class="status-badge ok">支持</span></td><td><span class="status-badge error">不支持</span></td><td>7.0 以下需 DST Root CA X3</td></tr>
+        <tr><td>Firefox (全版本)</td><td><span class="status-badge ok">支持</span></td><td><span class="status-badge ok">支持</span></td><td>内置自己的根 CA 列表</td></tr>
+        <tr><td>Chrome / Win / Mac</td><td><span class="status-badge ok">支持</span></td><td><span class="status-badge ok">支持</span></td><td>依赖系统根 CA</td></tr>
+        <tr><td>Java 11+</td><td><span class="status-badge ok">支持</span></td><td><span class="status-badge warn">部分</span></td><td>旧 JDK 版本可能有问题</td></tr>
+        <tr><td>OpenSSL 1.1.1+</td><td><span class="status-badge ok">支持</span></td><td><span class="status-badge ok">支持</span></td><td>—</td></tr>
+      </tbody>
+    </table>
+  </div>
+  <div class="card">
+    <div class="card-title">签名算法与密钥长度</div>
+    <table>
+      <thead><tr><th>类型</th><th>算法 / 长度</th><th>兼容性</th><th>说明</th></tr></thead>
+      <tbody>
+        <tr><td>签名算法</td><td>SHA-1 with RSA</td><td><span class="status-badge error">已废弃</span></td><td>2020 年起所有浏览器拒绝</td></tr>
+        <tr><td>签名算法</td><td>SHA-256 with RSA</td><td><span class="status-badge ok">通用</span></td><td>最低要求</td></tr>
+        <tr><td>椭圆曲线</td><td>ECDSA P-256</td><td><span class="status-badge ok">推荐</span></td><td>更小更快，渐成主流</td></tr>
+        <tr><td>椭圆曲线</td><td>ECDSA P-384</td><td><span class="status-badge ok">高安全</span></td><td>金融等高安全场景</td></tr>
+        <tr><td>RSA 密钥</td><td>2048-bit</td><td><span class="status-badge ok">最低要求</span></td><td>—</td></tr>
+        <tr><td>RSA 密钥</td><td>4096-bit</td><td><span class="status-badge warn">注意</span></td><td>老旧设备可能不支持</td></tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+
+<!-- Tab: Troubleshooting -->
+<div id="tab-troubleshoot" class="tab-content">
+  <div class="card">
+    <div class="card-title">排查决策树</div>
+    <div class="tree">
+      <div>1. 浏览器报证书错误？</div>
+      <div>&nbsp;&nbsp;|- 是 → DevTools → <strong>Security 面板</strong> 查看证书详情和路径</div>
+      <div>&nbsp;&nbsp;|- "证书已过期" → <strong style="color:var(--yellow)">检查有效期</strong> → 续期证书</div>
+      <div>&nbsp;&nbsp;|- "无法验证身份" → <strong style="color:var(--yellow)">检查证书链</strong> → 补全中间证书</div>
+      <div>&nbsp;&nbsp;|- "域名不匹配" → <strong style="color:var(--yellow)">检查 SAN/CN</strong> → 重新申请</div>
+      <div>&nbsp;&nbsp;|- "不受信任" → <strong style="color:var(--yellow)">检查根 CA</strong> → 自签名? 导入根证书</div>
+      <div>&nbsp;&nbsp;|- 控制台混合内容警告 → <strong style="color:var(--yellow)">检查资源 URL</strong> → 改用 HTTPS</div>
+      <div>&nbsp;&nbsp;|- 仍无法确定 → <strong>openssl s_client -connect site:443 -showcerts</strong></div>
+      <div>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;→ 使用 <a href="https://www.ssllabs.com/ssltest/" target="_blank">SSL Labs</a> 做全面检测</div>
+    </div>
+  </div>
+  <div class="card">
+    <div class="card-title">快速修复命令</div>
+    <div class="cmd-block">
+      <div class="cmd-title">检查证书有效期</div>
+      <div class="cmd-cmd"><span class="cmd-prompt">$</span> openssl x509 -in server.crt -noout -dates</div>
+      <div class="cmd-out">notBefore=Jun  1 00:00:00 2024 GMT
+notAfter=Jun  1 00:00:00 2025 GMT</div>
+    </div>
+    <div class="cmd-block">
+      <div class="cmd-title">检查证书支持的域名</div>
+      <div class="cmd-cmd"><span class="cmd-prompt">$</span> openssl x509 -in server.crt -noout -ext subjectAltName</div>
+      <div class="cmd-out">X509v3 Subject Alternative Name:
+    DNS:example.com, DNS:www.example.com</div>
+    </div>
+    <div class="cmd-block">
+      <div class="cmd-title">连接服务器检查证书链</div>
+      <div class="cmd-cmd"><span class="cmd-prompt">$</span> openssl s_client -connect example.com:443 -showcerts</div>
+      <div class="cmd-out">Verify return code: 0 (ok)</div>
+    </div>
+    <div class="cmd-block">
+      <div class="cmd-title">验证完整证书链</div>
+      <div class="cmd-cmd"><span class="cmd-prompt">$</span> openssl verify -CAfile root.crt -untrusted int.crt server.crt</div>
+      <div class="cmd-out">server.crt: OK</div>
+    </div>
+  </div>
+</div>
+
+<div class="footer">learn-network / examples / ssl / certificate-demo.html</div>
+
+<script>
+  // Tab switching
+  document.querySelectorAll('.tab').forEach(tab => {
+    tab.addEventListener('click', () => {
+      document.querySelectorAll('.tab').forEach(t => t.classList.remove('active'));
+      document.querySelectorAll('.tab-content').forEach(c => c.classList.remove('active'));
+      tab.classList.add('active');
+      document.getElementById('tab-' + tab.dataset.tab).classList.add('active');
+    });
+  });
+
+  // Certificate chain data
+  const chainData = {
+    valid: {
+      nodes: [
+        { type: 'root', icon: '🏛️', name: 'DigiCert Global Root G2', detail: '有效期: 2023-01-01 ~ 2043-01-01 · 受信任根CA', status: 'valid' },
+        { type: 'intermediate', icon: '📜', name: 'DigiCert SHA2 Extended Validation Server CA', detail: '有效期: 2023-08-01 ~ 2031-08-01 · 中间CA', status: 'valid' },
+        { type: 'server', icon: '🖥️', name: 'example.com', detail: '有效期: 2024-06-01 ~ 2025-06-01 · CN=example.com, SAN=example.com,www.example.com', status: 'valid' },
+      ],
+      explanation: '完整证书链：浏览器从服务器证书逐级验证到受信任根CA，连接安全。',
+      browserMsg: null
+    },
+    expired: {
+      nodes: [
+        { type: 'root', icon: '🏛️', name: 'DigiCert Global Root G2', detail: '有效期: 2023-01-01 ~ 2043-01-01 · 受信任根CA', status: 'valid' },
+        { type: 'intermediate', icon: '📜', name: 'DigiCert SHA2 Extended Validation Server CA', detail: '有效期: 2023-08-01 ~ 2031-08-01 · 中间CA', status: 'valid' },
+        { type: 'server', icon: '🖥️', name: 'example.com', detail: '⚠ 有效期: 2024-06-01 ~ 2025-01-15 · 已过期！', status: 'error' },
+      ],
+      explanation: '终端证书已过期。浏览器显示 ERR_CERT_EXPIRED，需要及时续期证书。',
+      browserMsg: { err: 'ERR_CERT_EXPIRED', detail: '此连接不是私密连接 — 攻击者可能会试图从 example.com 窃取信息' }
+    },
+    incomplete: {
+      nodes: [
+        { type: 'root', icon: '🏛️', name: 'DigiCert Global Root G2', detail: '有效期: 2023-01-01 ~ 2043-01-01 · 受信任根CA', status: 'valid' },
+        { type: 'intermediate', icon: '❓', name: '中间证书（未提供）', detail: '服务器未发送中间证书，浏览器无法验证到根CA', status: 'error' },
+        { type: 'server', icon: '🖥️', name: 'example.com', detail: '有效期: 2024-06-01 ~ 2025-06-01 · 但无法验证信任链', status: 'error' },
+      ],
+      explanation: '证书链不完整：服务器未发送中间证书，常见原因是Nginx配置了server.crt而非fullchain.pem。',
+      browserMsg: { err: 'ERR_CERT_AUTHORITY_INVALID', detail: '无法验证网站身份 — 证书颁发者无效' }
+    },
+    mismatch: {
+      nodes: [
+        { type: 'root', icon: '🏛️', name: 'DigiCert Global Root G2', detail: '有效期: 2023-01-01 ~ 2043-01-01 · 受信任根CA', status: 'valid' },
+        { type: 'intermediate', icon: '📜', name: 'DigiCert SHA2 Extended Validation Server CA', detail: '有效期: 2023-08-01 ~ 2031-08-01 · 中间CA', status: 'valid' },
+        { type: 'server', icon: '🖥️', name: 'example.com', detail: 'CN=example.com · 但访问的是 api.example.com（不匹配）', status: 'error' },
+      ],
+      explanation: '域名不匹配：证书的CN/SAN不包含当前访问的域名api.example.com。需要在申请证书时添加所有域名。',
+      browserMsg: { err: 'ERR_CERT_COMMON_NAME_INVALID', detail: '服务器证书的域名与访问的域名不匹配' }
+    },
+    selfsigned: {
+      nodes: [
+        { type: 'server', icon: '🔒', name: 'Self-Signed Certificate', detail: '自己签自己 · 根CA不在浏览器信任列表中', status: 'error' },
+      ],
+      explanation: '自签名证书：证书由自己签发，没有经过受信任CA的认证。开发/测试环境常见。',
+      browserMsg: { err: 'ERR_CERT_AUTHORITY_INVALID', detail: '证书颁发者无效/不受信任 — 自签名或私有CA签发' }
+    },
+    'root-expired': {
+      nodes: [
+        { type: 'root', icon: '🏛️', name: 'Thawte Primary Root CA', detail: '有效期: 2006-01-01 ~ 2021-01-01 · 已过期！', status: 'error' },
+        { type: 'intermediate', icon: '📜', name: 'Thawte SSL CA', detail: '有效期: 2020-01-01 ~ 2030-01-01 · 但根已过期', status: 'error' },
+        { type: 'server', icon: '🖥️', name: 'example.com', detail: '有效期: 2024-06-01 ~ 2025-06-01 · 但根CA已过期', status: 'error' },
+      ],
+      explanation: '根证书过期：即使服务器和中间证书都在有效期内，只要根CA过期，整条链就失效。老旧设备常见此问题。',
+      browserMsg: { err: 'CERT_HAS_EXPIRED', detail: '证书链中的根CA证书已过期' }
+    }
+  };
+
+  function renderChain(type) {
+    const container = document.getElementById('chain-display');
+    const data = chainData[type];
+    let html = '<div class="chain-container">';
+    data.nodes.forEach((node, i) => {
+      if (i > 0) html += '<div class="chain-arrow">⬇ 签名验证</div>';
+      const label = node.type === 'root' ? '根CA' : node.type === 'intermediate' ? '中间CA' : '服务器';
+      html += `
+        <div class="chain-node ${node.type} ${node.status === 'error' ? 'pulse-error' : ''}">
+          <span class="chain-node-label">${label}</span>
+          <span class="chain-node-icon">${node.icon}</span>
+          <div class="chain-node-info">
+            <div class="chain-node-name">${node.name}</div>
+            <div class="chain-node-detail">${node.detail}</div>
+          </div>
+          <span class="status-badge ${node.status === 'valid' ? 'ok' : 'error'}">${node.status === 'valid' ? '✓ 有效' : '✗ 无效'}</span>
+        </div>`;
+    });
+    html += '</div>';
+    container.innerHTML = html;
+    document.getElementById('explanation-text').textContent = data.explanation;
+    renderBrowserSim(data.browserMsg);
+  }
+
+  function renderBrowserSim(msg) {
+    const container = document.getElementById('browser-sim-panel');
+    if (!msg) {
+      container.innerHTML = `<div style="text-align:center;padding:2rem;color:var(--green);">
+        <div style="font-size:3rem;margin-bottom:1rem;">🔒</div>
+        <div style="font-size:1rem;font-weight:600;">连接安全</div>
+        <div style="font-size:0.8rem;color:var(--text-muted);margin-top:0.5rem;">证书链完整且在有效期内</div>
+      </div>`;
+      return;
+    }
+    container.innerHTML = `<div class="browser-sim">
+      <div class="browser-sim-header">
+        <span class="browser-sim-dot" style="background:#ef4444;"></span>
+        <span class="browser-sim-dot" style="background:#f59e0b;"></span>
+        <span class="browser-sim-dot" style="background:#22c55e;"></span>
+        <span style="color:var(--text-muted);font-size:0.7rem;margin-left:0.5rem;">chrome://net-internals/#ssl</span>
+      </div>
+      <div class="browser-sim-body">
+        <div class="icon">🔒</div>
+        <h3>您的连接不是私密连接</h3>
+        <p>攻击者可能会试图从 <strong>example.com</strong> 窃取您的信息。</p>
+        <div class="browser-sim-error">${msg.err}</div>
+        <p style="margin-top:0.75rem;font-size:0.75rem;color:var(--text-muted);">${msg.detail}</p>
+      </div>
+    </div>`;
+  }
+
+  // Init
+  renderChain('valid');
+  document.querySelectorAll('#chain-selector .selector-btn').forEach(btn => {
+    btn.addEventListener('click', () => {
+      document.querySelectorAll('#chain-selector .selector-btn').forEach(b => b.classList.remove('active'));
+      btn.classList.add('active');
+      renderChain(btn.dataset.type);
+    });
+  });
+
+  // OpenSSL commands data
+  const cmdData = {
+    info: {
+      title: '查看证书信息',
+      items: [
+        { label: '查看证书有效期', cmd: 'openssl x509 -in server.crt -noout -dates', out: 'notBefore=Jun  1 00:00:00 2024 GMT\nnotAfter=Jun  1 00:00:00 2025 GMT' },
+        { label: '查看证书支持的域名（SAN）', cmd: 'openssl x509 -in server.crt -noout -ext subjectAltName', out: 'X509v3 Subject Alternative Name:\n    DNS:example.com, DNS:www.example.com' },
+        { label: '查看证书指纹（用于对比）', cmd: 'openssl x509 -in server.crt -noout -fingerprint -sha256', out: 'SHA256 Fingerprint=43:5A:B2:AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD:EE:FF:2D' },
+        { label: '查看证书完整信息', cmd: 'openssl x509 -in server.crt -noout -text | head -20', out: 'Certificate:\n    Data:\n        Version: 3 (0x2)\n        Serial Number:\n            04:3f:c2:ae:12:3d:4e:5f:6a:7b:8c:9d:0e:1f:2a:3b\n        Signature Algorithm: sha256WithRSAEncryption\n        Issuer: C=US, O=DigiCert Inc, CN=DigiCert SHA2 Extended Validation Server CA' },
+      ]
+    },
+    chain: {
+      title: '检查证书链',
+      items: [
+        { label: '连接服务器查看完整证书链', cmd: 'openssl s_client -connect example.com:443 -showcerts', out: 'Certificate chain\n 0 s:example.com\n   i:/C=US/O=DigiCert Inc/CN=DigiCert SHA2 Extended Validation Server CA\n 1 s:/C=US/O=DigiCert Inc/CN=DigiCert SHA2 Extended Validation Server CA\n   i:/C=US/O=DigiCert Inc/CN=DigiCert Global Root G2' },
+        { label: '查看验证结果代码', cmd: 'openssl s_client -connect example.com:443 </dev/null 2>&1 | grep "Verify return code"', out: 'Verify return code: 0 (ok)' },
+        { label: '检查证书链完整性（部分链）', cmd: 'openssl s_client -connect example.com:443 -partial_chain -showcerts', out: 'Verify return code: 20 (unable to get local issuer certificate)' },
+      ]
+    },
+    verify: {
+      title: '验证证书',
+      items: [
+        { label: '使用 CA 验证服务器证书', cmd: 'openssl verify -CAfile ca.crt server.crt', out: 'server.crt: OK' },
+        { label: '验证完整证书链', cmd: 'openssl verify -CAfile root.crt -untrusted int.crt server.crt', out: 'server.crt: OK' },
+        { label: '常见验证返回码说明', cmd: '# 0  = 验证成功\n# 19 = 证书链不完整（根CA自签名）\n# 20 = 找不到中间证书\n# 21 = 无法验证到受信任根CA', out: null },
+      ]
+    },
+    match: {
+      title: '匹配私钥',
+      items: [
+        { label: '提取证书公钥指纹', cmd: 'openssl x509 -in cert.pem -pubkey -noout | openssl pkey -pubout -outform der | openssl md5', out: '(stdin)= 5d291e2ed3a6bafe3a0268e301a1b6cf' },
+        { label: '提取私钥公钥指纹', cmd: 'openssl pkey -in privkey.pem -pubout -outform der | openssl md5', out: '(stdin)= 5d291e2ed3a6bafe3a0268e301a1b6cf' },
+        { label: '对比两个指纹', cmd: '# 指纹相同则私钥与证书匹配', out: '如果两个指纹相同，说明私钥和证书是一对。' },
+      ]
+    }
+  };
+
+  function renderCmd(type) {
+    const container = document.getElementById('cmd-display');
+    const data = cmdData[type];
+    let html = '<div class="card"><div class="card-title">' + data.title + '</div>';
+    data.items.forEach(item => {
+      html += '<div class="cmd-block"><div class="cmd-title">' + item.label + '</div>';
+      html += '<div class="cmd-cmd"><span class="cmd-prompt">$</span> ' + item.cmd.replace(/</g, '&lt;') + '</div>';
+      if (item.out) html += '<div class="cmd-out">' + item.out + '</div>';
+      html += '</div>';
+    });
+    html += '</div>';
+    container.innerHTML = html;
+  }
+
+  // Init OpenSSL tab
+  renderCmd('info');
+  document.querySelectorAll('#cmd-selector .selector-btn').forEach(btn => {
+    btn.addEventListener('click', () => {
+      document.querySelectorAll('#cmd-selector .selector-btn').forEach(b => b.classList.remove('active'));
+      btn.classList.add('active');
+      renderCmd(btn.dataset.cmd);
+    });
+  });
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Add comprehensive SSL/TLS certificate troubleshooting documentation and an interactive HTML demo.

## Changes

### docs/ssl/certificate-issues.md
- 6 certificate issue types: expired cert, incomplete chain, domain mismatch, self-signed, root CA expired, mixed content
- Browser error code对照表 (Chrome/Firefox/Safari)
- OpenSSL troubleshooting commands
- Device/browser compatibility matrix
- Decision tree for troubleshooting

### examples/ssl/certificate-demo.html
Interactive HTML demo with 5 tabs:
- Certificate chain visualizer (6 scenarios)
- Browser error code对照表
- OpenSSL command reference
- Compatibility matrix
- Troubleshooting decision tree

## Testing
- [x] HTML demo loads without errors
- [x] All 6 certificate scenarios render correctly
- [x] Tab navigation works
- [x] OpenSSL command switching works