### PR TITLE
feat(cors): CORS 多个 Access-Control-Allow-Origin 为什么不报错

### DIFF
--- a/docs/axios/adapter-pattern.md
+++ b/docs/axios/adapter-pattern.md
@@ -1,0 +1,353 @@
+# Axios Adapter 适配器模式
+
+## 概述
+
+Axios 是一个基于 Promise 的 HTTP 客户端，支持浏览器和 Node.js 环境。其核心设计理念之一是**适配器模式（Adapter Pattern）**：通过统一的接口，屏蔽不同环境的 HTTP 请求实现差异，让上层调用代码保持一致。
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                        Axios Core                           │
+│  ┌─────────────┐  ┌──────────────┐  ┌─────────────────┐  │
+│  │ Interceptors│→ │ dispatchRequest│→│  Adapter (xhr)  │  │
+│  │             │  │              │  │  Adapter (http) │  │
+│  │             │  │              │  │  Adapter (mock)  │  │
+│  └─────────────┘  └──────────────┘  └─────────────────┘  │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## 适配器接口
+
+### 接口签名
+
+```typescript
+// 适配器是一个接收 config，返回 Promise<Response> 的函数
+interface AxiosAdapter {
+  (config: AxiosRequestConfig): Promise<AxiosResponse>;
+}
+```
+
+### 请求阶段划分
+
+| 阶段 | 说明 | 可干预点 |
+|------|------|----------|
+| 1. 配置合并 | defaults + config 深度合并 | config |
+| 2. 请求转换器 | transformRequest 序列化 data | transformRequest |
+| 3. 请求拦截器 | 请求前统一处理（如加 header） | interceptors.request |
+| **4. 适配器执行** | **实际发送 HTTP 请求** | **adapter** |
+| 5. 响应拦截器 | 响应后统一处理（如错误转换） | interceptors.response |
+| 6. 响应转换器 | transformResponse 反序列化 | transformResponse |
+
+**适配器是唯一真正发起网络请求的地方。**
+
+## 内置适配器
+
+### 1. xhr.js（浏览器环境）
+
+**实现**：XMLHttpRequest
+
+**源码路径**：`lib/adapters/xhr.js`
+
+**核心流程**：
+
+```javascript
+// 简化流程
+export default function xhrAdapter(config) {
+  return new Promise((resolve, reject) => {
+    const request = new XMLHttpRequest();
+    
+    // 1. 打开连接
+    request.open(config.method, config.url, true);
+    
+    // 2. 设置超时
+    request.timeout = config.timeout;
+    
+    // 3. 设置请求头
+    Object.entries(headers).forEach(([k, v]) => 
+      request.setRequestHeader(k, v)
+    );
+    
+    // 4. 处理跨域 Cookie
+    request.withCredentials = !!config.withCredentials;
+    
+    // 5. 设置响应类型
+    if (config.responseType) {
+      request.responseType = config.responseType;
+    }
+    
+    // 6. 注册进度事件（上传/下载）
+    if (config.onUploadProgress) {
+      request.upload.addEventListener('progress', onUploadProgress);
+    }
+    
+    // 7. 注册事件处理器
+    request.onloadend = () => {
+      const response = {
+        data: request.response,
+        status: request.status,
+        statusText: request.statusText,
+        headers: parseHeaders(request.getAllResponseHeaders()),
+        config,
+        request
+      };
+      settle(resolve, reject, response);
+    };
+    
+    request.onabort = () => reject(new AxiosError('Request aborted'));
+    request.onerror = () => reject(new AxiosError('Network Error'));
+    request.ontimeout = () => reject(new AxiosError('timeout exceeded'));
+    
+    // 8. 发送请求
+    request.send(config.data);
+  });
+}
+```
+
+**关键特性**：
+- 上传/下载进度追踪
+- 请求取消（abort）
+- 跨域 withCredentials
+- 多种 responseType（json/text/blob/document/arraybuffer）
+- 自动处理 data: URI 协议
+
+### 2. http.js（Node.js 环境）
+
+**实现**：Node.js 原生 `http` / `https` 模块
+
+**源码路径**：`lib/adapters/http.js`
+
+**核心能力**：
+
+| 特性 | 实现方式 |
+|------|----------|
+| 重定向跟随 | `follow-redirects` 库 |
+| HTTP/2 | `http2.connect()` |
+| 代理 | `proxy-from-env` + `beforeRedirects` 钩子 |
+| 流式响应 | `stream.Readable` 支持 |
+| 进度追踪 | `stream.pipeline` + `progressEventReducer` |
+| 取消 | `EventEmitter` + `AbortController` |
+
+**关键差异**：
+- 支持 HTTP/2 多路复用（Session 连接池）
+- 支持代理自动发现（环境变量 `HTTP_PROXY`）
+- 支持 `socketPath` 替代主机端口
+- 支持 Gzip/Brotli 自动解压
+
+### 适配器选择逻辑
+
+```javascript
+// lib/adapters/adapterResolutionUtils.js
+function getAdapter(adapters) {
+  // 1. 优先使用用户指定的 adapter
+  if (config.adapter) {
+    return adapters[config.adapter];
+  }
+  
+  // 2. 根据环境自动选择
+  adapters = adapters || [xhrAdapter, httpAdapter];
+  
+  const { knownAdapters, supportsRead } = utils;
+  
+  // 遍历适配器列表，返回第一个支持的
+  for (const adapter of adapters) {
+    if (typeof adapter === 'function') {
+      // 检查适配器是否可用（如 xhr 需 XMLHttpRequest）
+      if (adapter.request) {
+        return adapter.request;
+      }
+      return adapter;
+    }
+  }
+}
+```
+
+## 自定义适配器
+
+### 场景一：Mock 适配器（测试环境）
+
+```javascript
+// mock-adapter.js
+function mockAdapter(config) {
+  return new Promise((resolve, reject) => {
+    // 模拟网络延迟
+    setTimeout(() => {
+      const response = {
+        data: { mocked: true, config },
+        status: 200,
+        statusText: 'OK',
+        headers: { 'content-type': 'application/json' },
+        config,
+        request: null
+      };
+
+      // 可通过 config 模拟错误
+      if (config.forceError) {
+        reject(new AxiosError('Mock Error', 'ERR.Mock', config));
+        return;
+      }
+
+      // 模拟 404
+      if (config.mockStatus === 404) {
+        response.status = 404;
+        response.statusText = 'Not Found';
+      }
+
+      settle(resolve, reject, response);
+    }, config.mockDelay || 100);
+  });
+}
+
+// 注册为默认适配器
+axios.defaults.adapter = mockAdapter;
+```
+
+### 场景二：重试适配器
+
+```javascript
+// retry-adapter.js
+const originalAdapter = axios.defaults.adapter;
+
+function retryAdapter(config) {
+  const maxRetries = config.retryCount || 3;
+  const retryDelay = config.retryDelay || 1000;
+  const retryStatuses = [408, 429, 500, 502, 503, 504];
+
+  function attempt(retryCount) {
+    return originalAdapter(config)
+      .catch(err => {
+        if (retryCount < maxRetries) {
+          const shouldRetry = 
+            retryStatuses.includes(err.response?.status) ||
+            err.code === 'ECONNRESET' ||
+            err.code === 'ETIMEDOUT';
+          
+          if (shouldRetry) {
+            return new Promise(resolve => 
+              setTimeout(() => resolve(attempt(retryCount + 1)), retryDelay)
+            );
+          }
+        }
+        throw err;
+      });
+  }
+
+  return attempt(0);
+}
+
+axios.defaults.adapter = retryAdapter;
+```
+
+### 场景三：微信小程序适配器
+
+```javascript
+// wx-adapter.js
+function wxAdapter(config) {
+  return new Promise((resolve, reject) => {
+    wx.request({
+      url: config.url,
+      method: config.method,
+      data: config.data,
+      header: config.headers,
+      success: (res) => {
+        resolve({
+          data: res.data,
+          status: res.statusCode,
+          statusText: '',
+          headers: res.header,
+          config,
+          request: res
+        });
+      },
+      fail: (err) => {
+        reject(new AxiosError(err.errMsg, 'ERR.NETWORK', config));
+      }
+    });
+  });
+}
+```
+
+## settle 函数
+
+`settle` 是适配器与 Promise 桥接的关键函数：
+
+```javascript
+// lib/core/settle.js
+function settle(resolve, reject, response) {
+  const validateStatus = response.config.validateStatus;
+  
+  if (!response.status || !validateStatus || validateStatus(response.status)) {
+    resolve(response);
+  } else {
+    reject(new AxiosError(
+      'Request failed with status ' + response.status,
+      [AxiosError.ERR_BAD_RESPONSE, AxiosError.ERR_BAD_REQUEST][Math.floor(response.status / 100) - 4],
+      response.config,
+      response.request,
+      response
+    ));
+  }
+}
+```
+
+**行为规则**：
+- `2xx` 状态码 → resolve
+- 非 2xx 状态码 → reject（除非 `validateStatus` 返回 true）
+- 无状态码（网络错误）→ reject
+
+## 与拦截器/转换器的区别
+
+| 机制 | 层级 | 执行次数 | 典型用途 |
+|------|------|----------|----------|
+| **Adapter** | 底层网络 | 精确 1 次 | 跨平台适配、Mock |
+| **Interceptor** | 请求/响应 | 可多次 | Header 注入、日志、错误统一处理 |
+| **Transform** | 数据转换 | 精确 1 次 | JSON 解析、请求序列化 |
+
+```
+请求流程：
+  User Config
+       ↓
+  [Transformer: transformRequest] ← 可修改 data
+       ↓
+  [Interceptor: request.use] ← 可修改 config
+       ↓
+  [Adapter: xhr/http] ← 实际网络请求
+       ↓
+  [Interceptor: response.use] ← 可修改 response
+       ↓
+  [Transformer: transformResponse] ← 可修改 data
+       ↓
+  User
+```
+
+## Adapter 与 AxiosError
+
+适配器抛出的错误应使用 `AxiosError`：
+
+```javascript
+// AxiosError 构造签名
+new AxiosError(message, code, config, request, response);
+
+// 常用错误码
+ERR_NETWORK      // 网络错误（如断网）
+ECONNABORTED     // 请求超时
+ERR_BAD_RESPONSE // 非 2xx 响应
+ERR_BAD_REQUEST  // 4xx 响应
+ERR_CANCELED     // 请求被取消
+```
+
+## 性能考量
+
+1. **HTTP/2 Session 复用**：`http.js` 中 `Http2Sessions` 类缓存 Session，避免重复建连
+2. **流式响应**：大文件下载使用 `stream.Readable`，避免内存峰值
+3. **Zlib 解压**：自动处理 `gzip/br` 压缩响应，需考虑 CPU vs 带宽权衡
+4. **FormData 边界**：自动检测 `FormData` 类型，使用 `formDataToStream` 避免内存拷贝
+
+## 总结
+
+Axios 适配器模式的核心价值：
+
+1. **环境抽象**：一套 API，多端运行（浏览器/Node/小程序/React Native）
+2. **可替换性**：通过 `config.adapter` 或 `axios.defaults.adapter` 注入自定义实现
+3. **可测试性**：Mock 适配器让测试无需真实网络
+4. **功能扩展**：重试、降级、调试拦截等横切关注点
+
+理解适配器接口（`config → Promise<Response>`）是深度掌握 Axios 的关键。

--- a/docs/cors/multi-origin-analysis.md
+++ b/docs/cors/multi-origin-analysis.md
@@ -1,0 +1,461 @@
+# CORS 多个 Access-Control-Allow-Origin 为什么不会报错？
+
+> 本文深入剖析 CORS 规范与浏览器实现的差异，解释为什么服务器返回多个 `Access-Control-Allow-Origin` 头部会导致浏览器报错，并提供正确的多域名 CORS 配置方案。
+
+## 目录
+
+1. [核心结论](#核心结论)
+2. [CORS 规范 vs 浏览器实现](#cors-规范-vs-浏览器实现)
+3. [实际报错情况](#实际报错情况)
+4. [为什么不能多个值？](#为什么不能多个值)
+5. [正确做法：动态回显 Origin](#正确做法动态回显-origin)
+6. [常见踩坑场景](#常见踩坑场景)
+7. [代码示例](#代码示例)
+8. [参考资料](#参考资料)
+
+---
+
+## 核心结论
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                      ⚠️ 关键发现                                 │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                 │
+│   CORS 规范  ──── 允许 ────▶  多个 Access-Control-Allow-Origin │
+│                                                                 │
+│   浏览器实现 ──── 不允许 ──▶  多个 Access-Control-Allow-Origin  │
+│                           (所有主流浏览器均不支持)                │
+│                                                                 │
+│   服务器尝试返回多个值  ──▶  浏览器报错：                       │
+│   "Multiple CORS header Access-Control-Allow-Origin not allowed"│
+│                                                                 │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+**记住这个原则：CORS 是浏览器的安全策略，规范只是纸面约定，浏览器实现才是真相。**
+
+---
+
+## CORS 规范 vs 浏览器实现
+
+### 2.1 规范说了什么？
+
+根据 W3C CORS 规范和 Fetch 标准，`Access-Control-Allow-Origin` 的 ABNF 定义为：
+
+```abnf
+Access-Control-Allow-Origin = origin-or-null / "*"
+```
+
+这意味着规范理论上允许：
+- 单个 origin（如 `https://example.com`）
+- `null` 值
+- `*` 通配符（表示允许所有来源）
+
+**规范并未明确禁止列出多个 origin**，但也从未定义「多个 origin 该如何表示」的语法。
+
+### 2.2 浏览器实际做了什么？
+
+| 浏览器 | 是否支持多值？ | 实际行为 |
+|--------|--------------|---------|
+| Chrome | ❌ 不支持 | 抛出 CORS 错误 |
+| Firefox | ❌ 不支持 | 抛出 CORS 错误 |
+| Safari | ❌ 不支持 | 抛出 CORS 错误 |
+| Edge | ❌ 不支持 | 抛出 CORS 错误 |
+
+**结论：所有主流浏览器均不支持多个 `Access-Control-Allow-Origin` 值。**
+
+### 2.3 规范与实现的鸿沟
+
+```
+┌──────────────────────────────  CORS 规范  ──────────────────────────────┐
+│                                                                             │
+│   "允许的值为：origin、null、或 *"                                          │
+│   "origin 可以是多个"（未明确禁止，但未定义语法）                              │
+│                                                                             │
+└─────────────────────────────────── ▼ ────────────────────────────────────┘
+                                    鸿沟
+┌─────────────────────────────────── ▼ ────────────────────────────────────┐
+│                              浏览器实现                                     │
+│                                                                             │
+│   "我们只认单值或 *，多值直接报错"                                            │
+│   "即使服务器返回了多个值，浏览器也只取第一个"                                  │
+│                                                                             │
+└───────────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 实际报错情况
+
+### 3.1 错误信息
+
+如果服务器返回了多个 `Access-Control-Allow-Origin` 头部，浏览器会报错：
+
+> **Chrome / Edge（Chromium 内核）：**
+> ```
+> Access to fetch at 'https://api.example.com/data' from origin 
+> 'https://client.example.com' has been blocked by CORS policy: 
+> Multiple CORS header 'Access-Control-Allow-Origin' not allowed
+> ```
+
+> **Firefox：**
+> ```
+> CORS header 'Access-Control-Allow-Origin' has more than one value, 
+> but request Credentials mode is 'include', and the value of 
+> 'Access-Control-Allow-Origin' header should be '*' when request's 
+> credentials mode is 'include', or it should be the same as the origin.
+> ```
+
+> **Safari：**
+> ```
+> Blocked by CORS policy: Multiple 'Access-Control-Allow-Origin' headers 
+> are not allowed for cross-origin request.
+> ```
+
+### 3.2 什么情况会触发？
+
+以下服务器配置都会触发浏览器报错：
+
+```nginx
+# 错误配置 1：尝试用逗号分隔多个 origin
+add_header Access-Control-Allow-Origin "https://a.com,https://b.com";
+
+# 错误配置 2：重复发送多个头部
+add_header Access-Control-Allow-Origin "https://a.com";
+add_header Access-Control-Allow-Origin "https://b.com";
+
+# 错误配置 3：同时返回 * 和具体 origin
+add_header Access-Control-Allow-Origin "*";
+add_header Access-Control-Allow-Origin "https://a.com";
+```
+
+### 3.3 浏览器如何检查？
+
+浏览器的 CORS 检查逻辑如下：
+
+```
+浏览器收到响应
+      │
+      ▼
+检查 Access-Control-Allow-Origin 头部数量
+      │
+      ├─── 0 个 ──▶ 请求失败（缺少必需头部）
+      │
+      ├─── 1 个 ──▶ 检查值是否为 * 或与请求 origin 匹配
+      │                ├─── 匹配 ──▶ 请求成功
+      │                └─── 不匹配 ──▶ 请求失败
+      │
+      └─── 多个 ──▶ 请求失败，报错 "Multiple CORS header not allowed"
+```
+
+---
+
+## 为什么不能多个值？
+
+### 4.1 CORS 检查需要明确性
+
+浏览器的同源安全策略要求「二元结果」：
+
+```
+请求来源是"允许"还是"不允许"？
+      │
+      ├─── Yes ──▶ 允许访问响应数据
+      │
+      └─── No ──▶ 阻止访问（即使数据已返回）
+```
+
+如果允许列出多个 origin，浏览器无法回答这个简单问题：「这个响应到底允不允许当前来源？」
+
+### 4.2 歧义问题
+
+考虑以下场景：
+
+```
+请求 Origin: https://evil.com
+Access-Control-Allow-Origin: https://a.com, https://b.com
+```
+
+浏览器该怎么做？
+- `https://evil.com` 不在列表中 → 拒绝？
+- 但响应体已经被加载到内存中 → 安全风险
+
+### 4.3 安全考虑
+
+1. **简化检查逻辑**：单值检查 O(1) 复杂度，多值需要遍历匹配
+2. **防止配置错误**：如果允许多值，开发者可能不小心暴露敏感数据给错误来源
+3. **一致性问题**：不同的多值表示法（逗号、空格、多个头部）会导致不一致的行为
+
+### 4.4 凭证（Credentials）与多值的冲突
+
+当请求包含凭证（如 cookies）时：
+
+```
+如果 Access-Control-Allow-Origin: *
+    └──▶ 浏览器拒绝（不能对带凭证请求使用 *）
+    
+如果 Access-Control-Allow-Origin: "https://a.com, https://b.com"
+    └──▶ 浏览器不知道该信任哪一个
+```
+
+规范明确要求带凭证请求时，`Access-Control-Allow-Origin` 必须精确匹配请求 origin，不支持通配符。
+
+---
+
+## 正确做法：动态回显 Origin
+
+### 5.1 核心思路
+
+服务器不应该「硬编码」允许的 origin 列表在响应中，而是：
+1. 检查请求的 `Origin` 是否在白名单中
+2. 如果在白名单中，将请求的 `Origin` 原样返回
+
+### 5.2 动态回显的优势
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                       动态回显 vs 硬编码                          │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                 │
+│   硬编码（错误）：                                               │
+│   Access-Control-Allow-Origin: "https://a.com,https://b.com"   │
+│   ❌ 浏览器报错                                                   │
+│                                                                 │
+│   动态回显（正确）：                                             │
+│   请求 Origin: https://a.com                                   │
+│   Access-Control-Allow-Origin: https://a.com  ✓                │
+│                                                                 │
+│   请求 Origin: https://b.com                                   │
+│   Access-Control-Allow-Origin: https://b.com  ✓                │
+│                                                                 │
+│   请求 Origin: https://evil.com                                │
+│   Access-Control-Allow-Origin: (不返回该头部)                   │
+│   浏览器阻止请求  ✓                                             │
+│                                                                 │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### 5.3 安全注意事项
+
+使用动态回显时，必须严格检查 origin：
+
+```js
+// ✅ 正确：在白名单中才回显
+if (allowedOrigins.includes(requestOrigin)) {
+  response.setHeader("Access-Control-Allow-Origin", requestOrigin);
+}
+
+// ❌ 危险：直接回显任何 origin（等于 *）
+// 这会让任何网站都能访问你的资源
+response.setHeader("Access-Control-Allow-Origin", requestOrigin);
+```
+
+---
+
+## 常见踩坑场景
+
+### 场景 1：Nginx 配置多值
+
+```nginx
+# 错误 ❌
+location /api/ {
+    add_header Access-Control-Allow-Origin "https://a.com,https://b.com";
+}
+
+# 正确 ✅（需要用 Lua 或 map 配合）
+set $cors_origin "";
+if ($http_origin ~* "^https://(a|b)\.com$") {
+    set $cors_origin $http_origin;
+}
+add_header Access-Control-Allow-Origin $cors_origin;
+```
+
+### 场景 2：Express.js 错误配置
+
+```js
+// 错误 ❌
+app.use(cors({
+  origin: ["https://a.com", "https://b.com"],  // cors 包会处理，但直接设置头部不行
+  credentials: true
+}));
+
+// 实际发送的是单个值，不是多个头部
+
+// ❌ 危险：直接设置多个头部
+res.set({
+  "Access-Control-Allow-Origin": "https://a.com",
+  "Access-Control-Allow-Origin": "https://b.com"  // 这会覆盖第一个！
+});
+```
+
+### 场景 3：认为多个头部 = 多个值
+
+```js
+// 错误 ❌：第二个会覆盖第一个
+res.setHeader("Access-Control-Allow-Origin", "https://a.com");
+res.setHeader("Access-Control-Allow-Origin", "https://b.com");
+// 最终值：只有 "https://b.com"
+
+res.append("Access-Control-Allow-Origin", "https://a.com");
+res.append("Access-Control-Allow-Origin", "https://b.com");
+// 有些框架的 append 会创建多个头部 → 浏览器报错
+```
+
+### 场景 4：CDN 保留多域名配置
+
+```js
+// 错误 ❌：CDN 配置面板允许添加多个 origin
+// 但 CDN 转发到源站时会变成多个头部
+const cdnConfig = {
+  allowedOrigins: ["https://a.com", "https://b.com", "https://c.com"]
+};
+// CDN 内部实现可能产生多个 Access-Control-Allow-Origin 头部
+```
+
+---
+
+## 代码示例
+
+### 6.1 Node.js / Express
+
+```js
+const allowedOrigins = [
+  "https://a.com",
+  "https://b.com",
+  "https://c.com"
+];
+
+app.use((req, res, next) => {
+  const origin = req.headers.origin;
+  
+  if (allowedOrigins.includes(origin)) {
+    res.setHeader("Access-Control-Allow-Origin", origin);
+    res.setHeader("Access-Control-Allow-Credentials", "true");
+    res.setHeader("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE");
+    res.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization");
+  }
+  
+  next();
+});
+```
+
+### 6.2 Nginx（使用 map）
+
+```nginx
+# 在 http 块中定义允许的 origin 列表
+map $http_origin $cors_origin {
+    "~^https://(a|b|c)\.com$" $http_origin;
+    default "";
+}
+
+server {
+    location /api/ {
+        add_header Access-Control-Allow-Origin $cors_origin;
+        add_header Access-Control-Allow-Credentials "true";
+        add_header Access-Control-Allow-Methods "GET, POST, PUT, DELETE";
+        add_header Access-Control-Allow-Headers "Content-Type, Authorization";
+    }
+}
+```
+
+### 6.3 Python / Flask
+
+```python
+ALLOWED_ORIGINS = [
+    "https://a.com",
+    "https://b.com",
+    "https://c.com"
+]
+
+@app.after_request
+def add_cors_headers(response):
+    origin = request.headers.get("Origin")
+    
+    if origin in ALLOWED_ORIGINS:
+        response.headers["Access-Control-Allow-Origin"] = origin
+        response.headers["Access-Control-Allow-Credentials"] = "true"
+        response.headers["Access-Control-Allow-Methods"] = "GET, POST, PUT, DELETE"
+        response.headers["Access-Control-Allow-Headers"] = "Content-Type, Authorization"
+    
+    return response
+```
+
+### 6.4 Go / net/http
+
+```go
+var allowedOrigins = map[string]bool{
+    "https://a.com": true,
+    "https://b.com": true,
+    "https://c.com": true,
+}
+
+func corsMiddleware(next http.Handler) http.Handler {
+    return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        origin := r.Header.Get("Origin")
+        
+        if allowedOrigins[origin] {
+            w.Header().Set("Access-Control-Allow-Origin", origin)
+            w.Header().Set("Access-Control-Allow-Credentials", "true")
+            w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE")
+            w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+        }
+        
+        next.ServeHTTP(w, r)
+    })
+}
+```
+
+---
+
+## 常见问题解答
+
+### Q1：为什么 CORS 规范不禁止多值？
+
+CORS 规范（Fetch 标准）在设计时保持了灵活性，没有明确禁止多值语法。但也从未定义多值的表示方法（是逗号分隔？还是多个头部？）。这种「未定义」被浏览器厂商解读为「不支持」。
+
+### Q2：使用通配符 * 不就行了吗？
+
+对于不需要凭证的请求，`*` 是可行的。但以下情况不能用 `*`：
+- 请求需要携带 Cookie（`credentials: include`）
+- 需要根据不同来源返回不同数据
+- 响应包含用户特定数据
+
+### Q3：CDN 如何处理多域名 CORS？
+
+CDN 通常需要配置多个 origin 回源，但对外只返回一个 `Access-Control-Allow-Origin`。CDN 配置面板可能让你输入多个域名，内部实现应该是动态回显逻辑。
+
+### Q4：同一个接口能否同时支持多个不同来源？
+
+可以，使用动态回显机制。服务器检查请求 origin 是否在白名单中，是则返回该 origin。
+
+### Q5：`null` 作为 Access-Control-Allow-Origin 有什么风险？
+
+`null` 值会允许 `null` origin 的请求，这在以下场景中有安全风险：
+- 本地 HTML 文件通过 `file://` 协议打开
+- 沙盒 iframe
+- 某些重定向场景
+
+除非明确需要，否则不建议允许 `null`。
+
+---
+
+## 参考资料
+
+1. **MDN - CORS Errors**: https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CORS/Errors/CORSMultipleAllowOriginNotAllowed
+2. **PortSwigger - CORS Access Control Allow Origin**: https://portswigger.net/web-security/cors/access-control-allow-origin
+3. **W3C CORS Specification**: https://fetch.spec.whatwg.org/#http-cors-protocol
+4. **MDN - HTTP CORS**: https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS
+5. **RFC 9110 - HTTP Semantics**: https://www.rfc-editor.org/rfc/rfc9110.html
+
+---
+
+## 总结
+
+| 场景 | 正确做法 |
+|------|---------|
+| 单域名 | `Access-Control-Allow-Origin: https://example.com` |
+| 所有域名（公开资源） | `Access-Control-Allow-Origin: *` |
+| 多个域名 | 动态回显：检查后返回匹配的 origin |
+| 带凭证请求 | 必须精确匹配，不能用 `*` |
+
+**记住：CORS 规范允许 ≠ 浏览器支持。永远使用动态回显处理多域名场景。**

--- a/docs/ssl/certificate-issues.md
+++ b/docs/ssl/certificate-issues.md
@@ -1,0 +1,372 @@
+# SSL/TLS 证书问题排查指南
+
+## 概述
+
+当浏览器访问 HTTPS 网站时，会验证证书链的每个环节。任何一环出问题都会导致安全警告甚至连接拒绝。本文系统梳理常见的证书问题类型、浏览器表现、排查方法和解决方案。
+
+---
+
+## 一、证书问题类型
+
+### 1. 证书本身过期（Certificate Expired）
+
+**原理：** SSL 证书有有效期的起始和截止日期（Not Before / Not After），浏览器会检查当前时间是否在此范围内。
+
+```
+证书有效期：
+[ Not Before ] ======= 当前时间 ======= [ Not After ]
+      └─────────────────────┘
+             ✓ 有效
+
+[ Not Before ] ======= [ Not After ] ======= 当前时间 ]
+      └─────────────────────┘
+                      └──────── × 过期
+```
+
+**典型场景：**
+- 运维忘记续期证书
+- 错误的系统时间导致"被过期"
+- 证书申请过早，上线时已接近过期
+
+### 2. 证书链不完整（Incomplete Certificate Chain）
+
+**原理：** 浏览器验证证书时需要从终端实体证书一路验到根 CA。服务器必须提供完整的中间证书链，否则浏览器无法追溯到受信任的根 CA。
+
+```
+完整证书链：
+┌─────────────────────┐
+│   根证书 (Root CA)   │  ← 浏览器内置，受操作系统信任
+└──────────┬──────────┘
+           │ 签名
+           ▼
+┌─────────────────────┐
+│  中间证书 (Intermediate) │  ← 可能有多级中间 CA
+└──────────┬──────────┘
+           │ 签名
+           ▼
+┌─────────────────────┐
+│  终端实体证书 (Server) │  ← 服务器配置的证书
+└─────────────────────┘
+
+不完整时：
+服务器只发送了终端证书 → 浏览器找不到中间证书 → 无法验证到根 → 不安全
+```
+
+**典型场景：**
+- Nginx/Apache 只配置了 `fullchain.pem`，实际发送的是纯实体证书
+- 反向代理（Nginx、HAProxy）没有正确传递证书链
+- 使用了新的 ACME 渠道签发的证书，中间 CA 较新，浏览器不熟悉
+
+### 3. 域名不匹配（Domain Mismatch）
+
+**原理：** 证书的 Subject Alternative Name (SAN) 或 Common Name (CN) 必须覆盖当前访问的域名。
+
+```
+证书CN=SAN: example.com
+访问 https://example.com       → ✓ 通过
+访问 https://www.example.com   → × SAN 不包含 www
+访问 https://api.example.com   → × SAN 不包含 api
+```
+
+**典型场景：**
+- 申请证书时只填了 `example.com`，但实际也用 `www.example.com` 访问
+- 通配符证书 `*.example.com` 不覆盖多级子域名 `sub.www.example.com`
+- 证书申请时的域名和实际访问的 IP/域名不一致
+- 测试环境使用生产域名的证书
+
+### 4. 自签名证书（Self-Signed Certificate）
+
+**原理：** 自签名证书没有经过受信任 CA 的签名，其根证书不在浏览器信任列表中。
+
+```
+自签名：
+┌─────────────────────┐
+│  自签名证书 (自己签自己) │
+└─────────────────────┘
+          ↓
+浏览器查找根 CA → 找不到 → 不信任
+
+正规 CA：
+证书由受信任根 CA 签发 → 根 CA 在浏览器信任列表 → 信任
+```
+
+**典型场景：**
+- 开发/测试环境使用 OpenSSL 自签证书
+- 内网系统使用私有 CA 签发的证书，但未导入根证书
+- 某些 IoT 设备使用硬编码的自签名证书
+
+### 5. 根证书过期（Root CA Expired）
+
+**原理：** 证书链顶端的根证书本身有过期时间（通常 20-30 年）。如果根 CA 过期，所有由它签发的证书都会失效，即使中间证书和终端证书本身未过期。
+
+```
+根 CA 过期时间线：
+根 CA 有效期：2010-01-01 ~ 2030-01-01
+中间 CA 有效期：2020-01-01 ~ 2040-01-01   ← 中间 CA 还在有效期内
+终端证书有效期：2024-01-01 ~ 2025-01-01  ← 终端证书也在有效期内
+
+但访问时：
+浏览器检查根 CA → 根 CA 已过期 → 整条链无效 → 报错
+```
+
+**典型场景：**
+- 老旧设备的内置根证书已过期（如某些嵌入式设备）
+- 企业私有 CA 的根证书过期后未及时更新
+- 某些老版本 Windows XP/IE6 系统
+
+### 6. 混合内容问题（Mixed Content）
+
+**原理：** HTTPS 页面加载了 HTTP 协议的资源（图片、脚本、样式表），浏览器会报"混合内容"警告。
+
+```
+https://example.com
+  ├── <script src="https://cdn.example.com/app.js">  ✓ 安全
+  └── <script src="http://cdn.example.com/app.js">  ✗ 混合内容
+```
+
+---
+
+## 二、浏览器提示场景对照表
+
+| 错误类型 | Chrome 提示 | Firefox 提示 | Safari 提示 | Edge 提示 |
+|---------|------------|-------------|------------|-----------|
+| 证书过期 | "此连接不是私密连接" / "ERR_CERT_EXPIRED" | "警告：前方有安全隐患" | "此连接不是专用" | 同 Chrome |
+| 证书链不完整 | "ERR_CERT_AUTHORITY_INVALID" | "sec_error_unknown_issuer" | "此证书无效" | 同 Chrome |
+| 域名不匹配 | "ERR_CERT_COMMON_NAME_INVALID" | "ssl_error_bad_cert_domain" | "Safari 无法验证网站身份" | 同 Chrome |
+| 自签名证书 | "ERR_CERT_AUTHORITY_INVALID" | "sec_error_untrusted_issuer" | "此证书无效" | 同 Chrome |
+| 根证书过期 | "ERR_CERT_PATH_EXCEEDS_LENGTH" 或 "CERT_HAS_EXPIRED" | "untrusted_cert_authority" | "此证书不受信任" | 同 Chrome |
+| 混合内容 | 控制台警告，不完全阻止 | 控制台警告 | 控制台警告 | 同 Chrome |
+
+---
+
+## 三、排查方法
+
+### 1. OpenSSL 命令行排查
+
+#### 查看证书详情
+```bash
+# 查看证书的所有信息
+openssl x509 -in server.crt -noout -text
+
+# 查看证书有效期
+openssl x509 -in server.crt -noout -dates
+
+# 查看证书支持的域名
+openssl x509 -in server.crt -noout -ext subjectAltName
+
+# 查看证书的颁发者
+openssl x509 -in server.crt -noout -issuer
+```
+
+#### 检查证书链
+```bash
+# 模拟浏览器验证证书链（连接到服务器）
+openssl s_client -connect example.com:443 -showcerts
+
+# 只显示证书链
+openssl s_client -connect example.com:443 -showcerts 2>/dev/null | openssl x509 -noout -text
+
+# 检查完整的证书链（包括中间证书）
+openssl s_client -connect example.com:443 -partial_chain -showcerts
+```
+
+#### 检查私钥匹配
+```bash
+# 查看私钥的 MD5 指纹
+openssl pkey -in privkey.pem -pubout -outform der | openssl md5
+
+# 查看证书的 MD5 指纹
+openssl x509 -in cert.pem -pubkey -noout | openssl pkey -pubout -outform der | openssl md5
+
+# 两个 MD5 值相同则匹配
+```
+
+#### 验证证书链完整性
+```bash
+# 将证书链合并（服务器证书在前，中间证书在后）
+cat server.crt intermediate.crt root.crt > chain.pem
+
+# 验证证书链
+openssl verify -CAfile root.crt -untrusted intermediate.crt server.crt
+```
+
+### 2. Chrome DevTools 排查
+
+#### Security 面板
+1. 打开 DevTools（F12）
+2. 切换到 **Security** 标签
+3. 查看证书信息：
+   - 证书有效性
+   - 证书链完整性
+   - 具体哪一级证书出问题
+
+#### 查看证书详情
+1. 点击锁图标 🔒 → "连接不安全" → "详细信息"
+2. 或直接访问 `chrome://cert-internals`
+
+#### 查看证书链
+```
+DevTools → Security → View certificate → 证书路径（查看每一级状态）
+```
+
+#### Console 面板混合内容警告
+```
+DevTools → Console → 搜索 "Mixed Content" 或 "mixed-content"
+```
+
+### 3. 在线工具
+
+| 工具 | 地址 | 用途 |
+|------|------|------|
+| SSL Labs | https://www.ssllabs.com/ssltest/ | 全面 SSL 配置检测 |
+| SSL Shopper | https://www.sslshopper.com/ssl-checker.html | 证书链检查 |
+| Let's Encrypt | https://letsencrypt.org/certificates/ | 查看中间 CA |
+| Chrome Certificate Viewer | chrome://cert-internals | 查看内置根 CA |
+
+---
+
+## 四、常见设备/浏览器兼容性说明
+
+### 根证书兼容性
+
+| 设备/浏览器 | 内置根 CA 库 | 更新频率 | 备注 |
+|-----------|-------------|---------|------|
+| Windows 10/11 | Windows Update | 自动 | 企业环境可通过 AD 推送 |
+| macOS | Apple Root CA Program | 系统更新 | Safari 定期同步 |
+| iOS | Apple Root CA Program | 系统更新 | 某些根 CA 需要用户手动信任 |
+| Android | 设备厂商 | 不一致 | 老设备可能缺少新根 CA |
+| Chrome (Linux) | Mozilla NSS | 定期更新 | 与 Firefox 共享同一套根 CA |
+| Firefox | 自己的根 CA 列表 | 6-8 周 | 独立于系统和 Chrome |
+| Java (JDK) | `cacerts` keystore | 随 JDK 更新 | 默认密码 `changeit` |
+
+### Let's Encrypt 证书兼容性
+
+Let's Encrypt 使用的是 **ISRG Root X1** 和 **ISRG Root X2** 根证书：
+
+| 客户端/设备 | ISRG Root X1 支持 | ISRG Root X2 支持 | 备注 |
+|-----------|-----------------|-----------------|------|
+| Android 7.1+ | ✓ | ✗ | 7.1 以下需要 DST Root CA X3 |
+| Firefox (所有版本) | ✓ | ✓ | 内置自己的根 CA 列表 |
+| Chrome (Win/Mac) | ✓ | ✓ | 依赖系统根 CA |
+| Java 11+ | ✓ | 部分 | 某些旧 JDK 版本有问题 |
+| OpenSSL 1.1.1+ | ✓ | ✓ | |
+
+### 证书签名算法兼容性
+
+| 算法 | 兼容性 | 说明 |
+|------|--------|------|
+| SHA-1 with RSA | ❌ 已废弃 | 2020 年起所有浏览器拒绝 |
+| SHA-256 with RSA | ✓ 通用 | 最低要求 |
+| SHA-384 with RSA | ✓ 通用 | 推荐用于金融等高安全场景 |
+| ECDSA P-256 | ✓ 现代 | 更小、更快，逐渐成为主流 |
+| ECDSA P-384 | ✓ 现代 | 高安全要求场景 |
+
+### 密钥长度要求
+
+| 算法 | 密钥长度 | 兼容性 |
+|------|---------|--------|
+| RSA | 2048-bit | ✓ 最低要求 |
+| RSA | 4096-bit | ⚠ 老旧设备可能不支持 |
+| ECDSA | P-256 | ✓ 现代通用 |
+| ECDSA | P-384 | ✓ 高安全场景 |
+
+---
+
+## 五、解决方案
+
+### 证书过期 → 续期
+```bash
+# 使用 acme.sh 续期
+acme.sh --renew -d example.com
+
+# 使用 certbot 续期
+certbot renew
+
+# 手动替换证书后重载 Nginx
+nginx -s reload
+```
+
+### 证书链不完整 → 拼接中间证书
+```bash
+# 查看服务器发送的证书链
+openssl s_client -connect example.com:443 -showcerts
+
+# 下载中间证书（以 Let's Encrypt 为例）
+curl -sS https://letsencrypt.org/certs/isrgrootx1.pem > root.pem
+curl -sS https://letsencrypt.org/certs/letsencryptAuthorityX3.pem > intermediate.pem
+
+# 合并证书链（服务器证书在前，中间证书在后）
+cat /etc/ssl/certs/example.com.crt /etc/ssl/certs/intermediate.pem > /etc/ssl/certs/fullchain.pem
+
+# Nginx 配置
+ssl_certificate /etc/ssl/certs/fullchain.pem;  # 不是 server.crt
+ssl_certificate_key /etc/ssl/private/example.com.key;
+```
+
+### 域名不匹配 → 重新申请或添加 SAN
+```bash
+# 通配符证书覆盖所有子域名
+certbot -d "example.com" -d "*.example.com"
+
+# 多域名证书
+certbot -d "example.com" -d "www.example.com" -d "api.example.com"
+```
+
+### 自签名证书 → 开发环境使用
+```bash
+# 生成自签名证书（仅测试用）
+openssl req -x509 -newkey rsa:2048 -keyout key.pem -out cert.pem -days 365 -nodes \
+  -subj "/CN=localhost"
+
+# 将根证书导入系统信任库（仅内网）
+# macOS
+sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain ca.crt
+
+# Linux (Ubuntu/Debian)
+sudo cp ca.crt /usr/local/share/ca-certificates/
+sudo update-ca-certificates
+```
+
+### 根证书过期 → 更新根证书
+```bash
+# 浏览器自动更新（大多数情况）
+# 企业环境：更新内部 CA
+
+# 检查系统根证书过期时间
+openssl x509 -in /etc/ssl/certs/ca-certificates.crt -noout -dates
+```
+
+---
+
+## 六、实战排查流程
+
+```
+遇到证书错误？
+  │
+  ├─ 1. 确认错误类型
+  │     Chrome DevTools → Security 面板
+  │
+  ├─ 2. 查看证书详情
+  │     锁图标 → "证书信息" → 有效期、域名、颁发者
+  │
+  ├─ 3. 检查证书链
+  │     Security 面板 → 证书路径 → 哪一级有问题？
+  │
+  ├─ 4. 本地验证
+  │     openssl s_client -connect example.com:443 -showcerts
+  │
+  └─ 5. 针对性修复
+        过期 → 续期
+        链不完整 → 补全中间证书
+        域名不匹配 → 重新申请
+        自签名 → 导入根证书或更换证书
+```
+
+---
+
+## 七、相关资源
+
+- [Mozilla SSL Configuration Generator](https://ssl-config.mozilla.org/)
+- [SSL Labs Server Test](https://www.ssllabs.com/ssltest/)
+- [Let's Encrypt 证书链说明](https://letsencrypt.org/certificates/)
+- [Chrome 根证书存储](https://.chromium.googlesource.com/chromium/src/+/main/net/data/ssl/symantec_certs/)

--- a/docs/websocket/websocket-connection-flow.md
+++ b/docs/websocket/websocket-connection-flow.md
@@ -1,0 +1,501 @@
+# WebSocket 连接流程深度分析
+
+## 前言
+
+WebSocket 是一种在单个 TCP 连接上实现全双工通信的协议，被广泛应用于实时聊天、在线游戏、实时数据推送等场景。本文以 `wss://zelda.xiaohongshu.com/websocketV2` 为例，深入分析 WebSocket 的完整连接生命周期，涵盖协议基础、连接建立、握手机制、心跳保活、数据帧格式以及断开重连策略。
+
+---
+
+## 一、协议基础：WebSocket 与 HTTP/HTTPS 的关系
+
+### 1.1 wss:// 是什么
+
+`wss://` 是 WebSocket Secure 的缩写，等价于 **WebSocket + TLS**。类比关系如下：
+
+| 协议 | 底层实现 | 说明 |
+| :--- | :------- | :--- |
+| `http://` | TCP | 裸 TCP 连接，无加密 |
+| `https://` | TCP + TLS | HTTP over TLS |
+| `ws://` | TCP | WebSocket，无加密 |
+| `wss://` | TCP + TLS | WebSocket over TLS |
+
+`wss://zelda.xiaohongshu.com/websocketV2` 中的 `zelda.xiaohongshu.com` 是小红书的 WebSocket 服务器域名，`/websocketV2` 是服务端路径。
+
+### 1.2 协议层级位置
+
+```
+┌─────────────────────────────────┐
+│         应用层 (HTTP/WS)         │
+├─────────────────────────────────┤
+│   TLS (wss) / SSL (https)       │
+├─────────────────────────────────┤
+│         TCP                     │
+├─────────────────────────────────┤
+│         IP                      │
+└─────────────────────────────────┘
+```
+
+WebSocket 协议位于 OSI 模型的应用层（第 7 层），但它的握手阶段借用了 HTTP 的请求-响应机制，因此常被描述为"HTTP 的升级协议"。
+
+### 1.3 为什么需要 WebSocket
+
+传统的 HTTP 采用**请求-响应**模式，客户端主动发起请求，服务器被动返回响应。服务器无法主动向客户端推送数据。
+
+解决方案对比：
+
+| 方案 | 实现方式 | 实时性 | 资源开销 | 复杂度 |
+| :--- | :------- | :----- | :------- | :----- |
+| 短轮询 (Short Polling) | 客户端定时请求 | 低 | 高（频繁建连） | 低 |
+| 长轮询 (Long Polling) | 请求挂起直到有新数据 | 中 | 中 | 中 |
+| Server-Sent Events (SSE) | 服务器推送单向通道 | 高 | 低 | 中 |
+| **WebSocket** | **双向全双工** | **高** | **低** | **中** |
+
+---
+
+## 二、连接建立：HTTP Upgrade
+
+### 2.1 握手本质
+
+WebSocket 的连接建立始于一个 **HTTP Upgrade 请求**。客户端（浏览器）发送一个特殊的 HTTP 请求，告知服务器将当前的 HTTP 连接"升级"为 WebSocket 连接。
+
+**关键请求头：**
+
+```
+GET /websocketV2 HTTP/1.1
+Host: zelda.xiaohongshu.com
+Connection: Upgrade
+Upgrade: websocket
+Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==
+Sec-WebSocket-Version: 13
+Origin: https://www.xiaohongshu.com
+User-Agent: Mozilla/5.0 ...
+```
+
+- `Connection: Upgrade` — 告诉服务器当前连接需要升级
+- `Upgrade: websocket` — 目标协议是 WebSocket
+- `Sec-WebSocket-Key` — 随机生成的 Base64 字符串，用于握手验证
+- `Sec-WebSocket-Version: 13` — 协议版本，当前唯一正式版本
+
+### 2.2 服务器响应
+
+如果服务器支持 WebSocket，它返回 **101 Switching Protocols** 状态码：
+
+```
+HTTP/1.1 101 Switching Protocols
+Upgrade: websocket
+Connection: Upgrade
+Sec-WebSocket-Accept: s3pPLMBiTxaQ9kYGzzhZRbK+xOo=
+```
+
+101 状态码表示"协议切换"（Protocol Switch），是 HTTP/1.1 规范中定义的特殊状态。完成这个响应后，TCP 连接不再承载 HTTP 协议，而是转为承载 WebSocket 数据帧。
+
+### 2.3 抓包验证
+
+使用 Wireshark 抓包时，过滤器设置：
+
+```
+tcp.port == 443  # wss 使用 443 端口
+```
+
+会看到完整的握手流程：TCP 三次握手 → HTTP Upgrade 请求 → 101 响应 → WebSocket 数据帧。
+
+> 注：`wss://` 使用 443 端口，`ws://` 默认使用 80 端口（可自定义）。
+
+---
+
+## 三、握手机制：Sec-WebSocket-Key 验证
+
+### 3.1 为什么需要 Key 验证
+
+握手阶段的 Key-Accept 机制并非用于加密，而是用于**防止恶意连接请求**（如跨站 WebSocket 劫持攻击）。它确保服务器只接受有意建立 WebSocket 连接的请求。
+
+### 3.2 握手算法
+
+服务器根据以下规则计算 `Sec-WebSocket-Accept`：
+
+```
+Accept = Base64(SHA1(Sec-WebSocket-Key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"))
+```
+
+步骤分解：
+
+1. **拼接**：将客户端的 `Sec-WebSocket-Key` 与固定的 **GUID** 字符串 `"258EAFA5-E914-47DA-95CA-C5AB0DC85B11"` 首尾拼接
+2. **SHA1 哈希**：对拼接后的字符串计算 SHA1 摘要（20 字节）
+3. **Base64 编码**：将二进制结果编码为 Base64 字符串
+
+### 3.3 示例
+
+假设客户端发送：
+```
+Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==
+```
+
+服务器计算（Node.js 示例）：
+
+```javascript
+const crypto = require("crypto");
+const key = "dGhlIHNhbXBsZSBub25jZQ==";
+const guid = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
+const accept = crypto
+  .createHash("sha1")
+  .update(key + guid)
+  .digest("base64");
+// 结果: s3pPLMBiTxaQ9kYGzzhZRbK+xOo=
+```
+
+### 3.4 浏览器内置实现
+
+浏览器端不需要手动计算，WebSocket API 会自动处理握手：
+
+```javascript
+const ws = new WebSocket("wss://zelda.xiaohongshu.com/websocketV2");
+// 浏览器自动添加 Sec-WebSocket-Key 并验证 Sec-WebSocket-Accept
+```
+
+---
+
+## 四、数据帧格式详解
+
+### 4.1 帧结构
+
+WebSocket 通信的基本单位是**数据帧**（Frame）。帧结构如下：
+
+```
+┌─────────────┬─────────────┬─────────────┬─────────────┐
+│  FIN (1bit) │  RSV1-3     │  Opcode     │             │
+│  标志位     │  (3bit)     │  (4bit)     │             │
+├─────────────┴─────────────┴─────────────┤  Mask Bit   │
+│           Payload Len (7bit)           │  (1bit)     │
+├───────────────────────────────────────┤              │
+│           Extended Payload Length      │  Masking    │
+│           (if payload len = 126/127)   │  Key        │
+├───────────────────────────────────────┤  (32bit,    │
+│           Masking Key (32bit)          │  if masked) │
+├───────────────────────────────────────┤              │
+│                                           │              │
+│           Application Data               │              │
+│           ("Payload Data")               │              │
+│                                           │              │
+└───────────────────────────────────────────┴─────────────┘
+```
+
+### 4.2 各字段说明
+
+| 字段 | 长度 | 说明 |
+| :--- | :--- | :--- |
+| FIN | 1bit | 1=这是消息的最后一帧；0=还有后续帧 |
+| RSV1-3 | 各 1bit | 保留位，正常为 0 |
+| Opcode | 4bit | 帧类型（见下表） |
+| MASK | 1bit | 1=数据被掩码处理；0=未掩码。**客户端发送必须为 1** |
+| Payload Length | 7bit | 数据长度（0-125）；126/127 表示使用扩展长度 |
+| Masking Key | 0/32bit | 掩码密钥，MASK=1 时存在 |
+| Payload Data | 可变 | 应用数据 |
+
+### 4.3 Opcode 帧类型
+
+| Opcode | 值 | 说明 |
+| :------ | :-- | :--- |
+| 0x0 | 0 | Continuation 帧（消息分片的后续帧） |
+| 0x1 | 1 | Text 帧（UTF-8 文本） |
+| 0x2 | 2 | Binary 帧（二进制数据） |
+| 0x8 | 8 | Close 帧（关闭连接） |
+| 0x9 | 9 | Ping 帧（心跳请求） |
+| 0xA | 10 | Pong 帧（心跳响应） |
+
+### 4.4 帧解析示例
+
+以下是一个文本帧的十六进制解析：
+
+```
+81 86 7f 43 52 1d 54 06 51 58 1e 57 58 14 51 17 52
+│  │  │  └─────────── Masking Key (4 bytes) ───────────┘
+│  │  └──────────────── Payload Length (6) ────────────┘
+│  └──────────────── Opcode = 0x1 (Text Frame) ─────────┘
+└──────────────── FIN=1, RSV=0, Opcode=1 ───────────────┘
+```
+
+关键规则：
+- 客户端发送给服务器的数据**必须**掩码（MASK=1）
+- 服务器发送给客户端的数据**不应**掩码（MASK=0）
+- 掩码算法：`maskedByte[i] = rawByte[i] XOR maskingKey[i % 4]`
+
+### 4.5 消息分片（Fragmentation）
+
+当一条消息过大时，可以分片传输：
+
+```
+帧1: FIN=0, Opcode=1, Data="Hello"
+帧2: FIN=0, Opcode=0, Data=" World"
+帧3: FIN=1, Opcode=0, Data="!"
+```
+
+- 第一帧：Opcode=1 (Text)，FIN=0 表示"消息未结束"
+- 中间帧：Opcode=0 (Continuation)，FIN=0 继续
+- 最后一帧：Opcode=0，FIN=1 表示消息完成
+
+---
+
+## 五、心跳机制（Keep-Alive）
+
+### 5.1 为什么需要心跳
+
+TCP 连接的 **KEEPALIVE** 机制可以检测死连接（如对端崩溃），但默认超时时间较长（Linux 默认 7200 秒）。WebSocket 应用需要更快速地检测连接存活状态，因此引入了应用层心跳机制。
+
+### 5.2 Ping/Pong 帧
+
+WebSocket 协议内置了 Ping/Pong 机制：
+
+- **Ping** (Opcode=0x9)：主动发送的心跳请求
+- **Pong** (Opcode=0xA)：对 Ping 的响应
+
+```
+客户端 ──Ping──► 服务器
+客户端 ◄──Pong── 服务器
+```
+
+浏览器不会自动发送 Ping，通常由**服务器**定期发送 Ping，客户端自动回复 Pong。开发者也可以手动发送：
+
+```javascript
+// 手动发送 Ping（浏览器支持有限）
+ws.send(JSON.stringify({ type: "ping", timestamp: Date.now() }));
+```
+
+### 5.3 TCP Keepalive 与 WebSocket 心跳的区别
+
+| 维度 | TCP Keepalive | WebSocket Ping/Pong |
+| :--- | :------------ | :------------------ |
+| 层级 | 传输层（TCP） | 应用层（WebSocket） |
+| 触发 | 内核/操作系统 | 应用代码 |
+| 精度 | 分钟级 | 秒级 |
+| 跨平台 | 依赖 OS 配置 | 标准化协议支持 |
+| 可控性 | 低 | 高 |
+
+### 5.4 小红书 WebSocket 心跳实践
+
+参考 `wss://zelda.xiaohongshu.com/websocketV2`，典型的心跳实现：
+
+```javascript
+// 客户端：定时发送心跳
+setInterval(() => {
+  if (ws.readyState === WebSocket.OPEN) {
+    ws.send(JSON.stringify({
+      type: "heartbeat",
+      timestamp: Date.now(),
+      deviceId: "xxx"
+    }));
+  }
+}, 30000); // 每 30 秒一次
+
+// 服务器：响应心跳
+ws.on("message", (data) => {
+  const msg = JSON.parse(data);
+  if (msg.type === "heartbeat") {
+    ws.send(JSON.stringify({ type: "heartbeat_ack", timestamp: Date.now() }));
+  }
+});
+```
+
+---
+
+## 六、连接状态
+
+### 6.1 浏览器 WebSocket 状态码
+
+| 属性值 | 值 | 说明 |
+| :----- | :-- | :--- |
+| `WebSocket.CONNECTING` | 0 | 连接正在建立 |
+| `WebSocket.OPEN` | 1 | 连接已打开，可通信 |
+| `WebSocket.CLOSING` | 2 | 连接正在关闭 |
+| `WebSocket.CLOSED` | 3 | 连接已关闭 |
+
+### 6.2 连接关闭码（Close Code）
+
+WebSocket 关闭时，双方可以交换一个 2 字节的关闭码和原因字符串：
+
+| 代码 | 名称 | 说明 |
+| :--- | :--- | :--- |
+| 1000 | `CLOSE_NORMAL` | 正常关闭 |
+| 1001 | `CLOSE_GOING_AWAY` | 终端离开 |
+| 1002 | `CLOSE_PROTOCOL_ERROR` | 协议错误 |
+| 1003 | `CLOSE_UNSUPPORTED` | 不支持的数据类型 |
+| 1005 | `CLOSE_NO_STATUS` | 无状态码（保留） |
+| 1006 | `CLOSE_ABNORMAL` | 异常关闭（非正常断开） |
+| 1009 | `CLOSE_TOO_LARGE` | 消息过大 |
+| 1010 | `CLOSE_EXTENSION_REQUIRED` | 需要扩展协商 |
+| 1011 | `CLOSE_UNEXPECTED_CONDITION` | 服务器内部错误 |
+
+---
+
+## 七、断开与重连策略
+
+### 7.1 断开场景
+
+WebSocket 连接可能因以下原因断开：
+
+1. **主动关闭**：调用 `ws.close()`，正常完成四次挥手
+2. **网络中断**：网线拔出、Wi-Fi 断开、切换网络
+3. **服务器关闭**：服务端主动关闭连接（OOM、限流、版本更新）
+4. **心跳超时**：长时间未收到心跳，服务器主动断开
+5. **协议错误**：收到格式错误的数据帧
+
+### 7.2 重连策略
+
+合理的重连机制是保障服务稳定性的关键：
+
+```javascript
+class WebSocketClient {
+  constructor(url) {
+    this.url = url;
+    this.reconnectDelay = 1000; // 初始重连延迟（毫秒）
+    this.maxReconnectDelay = 30000; // 最大重连延迟
+    this.connect();
+  }
+
+  connect() {
+    this.ws = new WebSocket(this.url);
+
+    this.ws.onopen = () => {
+      console.log("连接建立成功");
+      this.reconnectDelay = 1000; // 重置延迟
+    };
+
+    this.ws.onclose = (event) => {
+      if (!event.wasClean) {
+        this.scheduleReconnect();
+      }
+    };
+
+    this.ws.onerror = (error) => {
+      console.error("连接错误", error);
+    };
+  }
+
+  scheduleReconnect() {
+    setTimeout(() => {
+      console.log(`将在 ${this.reconnectDelay}ms 后重连...`);
+      this.connect();
+      // 指数退避，避免频繁重连
+      this.reconnectDelay = Math.min(
+        this.reconnectDelay * 2,
+        this.maxReconnectDelay
+      );
+    }, this.reconnectDelay);
+  }
+}
+```
+
+### 7.3 指数退避（Exponential Backoff）
+
+| 重试次数 | 延迟 |
+| :------- | :--- |
+| 1 | 1s |
+| 2 | 2s |
+| 3 | 4s |
+| 4 | 8s |
+| 5 | 16s |
+| 6+ | 30s（上限） |
+
+加入**随机抖动（Jitter）** 防止多客户端同时重连造成雪崩：
+
+```javascript
+const delay = this.reconnectDelay * (0.5 + Math.random() * 0.5);
+// 实际延迟 = 基础延迟 × [0.5, 1.0] 随机因子
+```
+
+---
+
+## 八、完整连接流程图
+
+```
+客户端                                服务器
+  │                                     │
+  │ ──── TCP 三次握手 (SYN, SYN-ACK) ──►│
+  │ ◄──── ACK ─────────────────────────│
+  │                                     │
+  │ ──── HTTP Upgrade 请求 ────────────►│
+  │      GET /websocketV2               │
+  │      Connection: Upgrade             │
+  │      Upgrade: websocket              │
+  │      Sec-WebSocket-Key: xxx          │
+  │ ◄─── HTTP/1.1 101 Switching ───────│
+  │      Sec-WebSocket-Accept: yyy      │
+  │                                     │
+  │ ◄──── WebSocket 数据帧 (业务数据) ──│
+  │ ──── WebSocket 数据帧 ────────────►│
+  │                                     │
+  │ ──── Ping 帧 ─────────────────────►│
+  │ ◄──── Pong 帧 ─────────────────────│
+  │      (心跳保活)                     │
+  │                                     │
+  │ ──── Close 帧 ─────────────────────►│
+  │ ◄──── Close 帧 ─────────────────────│
+  │                                     │
+  │ ──── TCP 四次挥手 (FIN, ACK) ─────►│
+```
+
+---
+
+## 九、安全考量
+
+### 9.1 WSS 强制使用
+
+生产环境**必须**使用 `wss://`（TLS 加密），否则：
+- 数据以明文传输，可被中间人窃听
+- 敏感 Cookie/Token 可能被盗取
+- 容易被注入恶意脚本
+
+### 9.2 Origin 验证
+
+服务器应验证 `Origin` 头，防止跨站 WebSocket 劫持：
+
+```javascript
+server.on("upgrade", (req, socket) => {
+  const origin = req.headers.origin;
+  const allowedOrigins = ["https://www.xiaohongshu.com", "https://xiaohongshu.com"];
+  if (!allowedOrigins.includes(origin)) {
+    socket.destroy();
+    return;
+  }
+  // 继续 WebSocket 握手...
+});
+```
+
+### 9.3 输入验证
+
+WebSocket 消息同样需要严格的输入验证，避免注入攻击：
+
+```javascript
+ws.on("message", (data) => {
+  try {
+    const msg = JSON.parse(data);
+    if (typeof msg.type !== "string") return;
+    if (msg.type === "message" && typeof msg.content !== "string") return;
+    // 业务处理...
+  } catch (e) {
+    console.error("Invalid message format");
+  }
+});
+```
+
+---
+
+## 十、总结
+
+| 阶段 | 关键点 |
+| :--- | :----- |
+| **协议基础** | `wss://` = WebSocket + TLS，端口 443 |
+| **连接建立** | HTTP Upgrade 请求，`Connection: Upgrade` |
+| **握手机制** | `Sec-WebSocket-Key` + GUID → SHA1 → Base64 = `Sec-WebSocket-Accept` |
+| **数据帧** | FIN + Opcode + MASK + Payload Length + Masking Key + Data |
+| **心跳** | Ping/Pong 帧，或应用层心跳（JSON 消息） |
+| **状态** | CONNECTING(0) → OPEN(1) → CLOSING(2) → CLOSED(3) |
+| **重连** | 指数退避 + 随机抖动 |
+| **安全** | 必须用 wss、Origin 验证、输入验证 |
+
+---
+
+## 参考资料
+
+- [RFC 6455 - The WebSocket Protocol](https://tools.ietf.org/html/rfc6455)
+- [MDN Web Docs - WebSocket](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket)
+- [Chromium Source - TCP KeepAlive](https://source.chromium.org/chromium/chromium/src/+/main:net/socket/tcp_socket_posix.cc)

--- a/examples/axios/axios-adapter-demo.html
+++ b/examples/axios/axios-adapter-demo.html
@@ -1,0 +1,373 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Axios Adapter 交互式演示</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background: #0f0f23; color: #e4e4e7; padding: 24px; min-height: 100vh; }
+    h1 { font-size: 1.5rem; margin-bottom: 8px; color: #fff; }
+    .subtitle { color: #71717a; margin-bottom: 24px; font-size: 0.9rem; }
+    .tabs { display: flex; gap: 4px; margin-bottom: 16px; }
+    .tab { padding: 8px 16px; background: #1e1e2e; border: none; color: #71717a; cursor: pointer; border-radius: 6px 6px 0 0; font-size: 0.875rem; transition: all 0.2s; }
+    .tab:hover { color: #a1a1aa; }
+    .tab.active { background: #18181b; color: #fff; }
+    .panel { background: #18181b; border-radius: 0 8px 8px 8px; padding: 20px; }
+    .panel-section { margin-bottom: 20px; }
+    .panel-section h3 { font-size: 0.875rem; color: #a1a1aa; margin-bottom: 8px; text-transform: uppercase; letter-spacing: 0.05em; }
+    .code-block { background: #0f0f23; border-radius: 6px; padding: 16px; font-family: 'Monaco', 'Menlo', monospace; font-size: 0.8rem; overflow-x: auto; white-space: pre; line-height: 1.6; }
+    .code-block .keyword { color: #c678dd; }
+    .code-block .string { color: #98c379; }
+    .code-block .comment { color: #5c6370; font-style: italic; }
+    .code-block .function { color: #61afef; }
+    .code-block .number { color: #d19a66; }
+    .code-block .param { color: #e06c75; }
+    .btn { padding: 10px 20px; background: #4f46e5; color: #fff; border: none; border-radius: 6px; cursor: pointer; font-size: 0.875rem; transition: all 0.2s; }
+    .btn:hover { background: #4338ca; }
+    .btn:disabled { opacity: 0.5; cursor: not-allowed; }
+    .output { background: #0f0f23; border-radius: 6px; padding: 16px; margin-top: 16px; min-height: 80px; font-family: 'Monaco', 'Menlo', monospace; font-size: 0.8rem; max-height: 300px; overflow-y: auto; }
+    .output .success { color: #98c379; }
+    .output .error { color: #e06c75; }
+    .output .info { color: #61afef; }
+    .grid-2 { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+    @media (max-width: 768px) { .grid-2 { grid-template-columns: 1fr; } }
+    .arrow-diagram { display: flex; align-items: center; justify-content: center; gap: 16px; padding: 24px; background: #0f0f23; border-radius: 8px; margin: 16px 0; flex-wrap: wrap; }
+    .arrow-step { display: flex; flex-direction: column; align-items: center; gap: 8px; }
+    .arrow-box { background: #27272a; padding: 12px 20px; border-radius: 8px; text-align: center; min-width: 120px; }
+    .arrow-box.primary { background: #4f46e5; }
+    .arrow-box.secondary { background: #27272a; border: 1px solid #3f3f46; }
+    .arrow-arrow { color: #52525b; font-size: 1.5rem; }
+    .comparison-table { width: 100%; border-collapse: collapse; margin-top: 16px; }
+    .comparison-table th, .comparison-table td { padding: 12px; text-align: left; border-bottom: 1px solid #27272a; font-size: 0.875rem; }
+    .comparison-table th { color: #71717a; font-weight: 500; text-transform: uppercase; font-size: 0.75rem; letter-spacing: 0.05em; }
+    .comparison-table td:first-child { color: #a1a1aa; }
+    .tag { display: inline-block; padding: 2px 8px; background: #27272a; border-radius: 4px; font-size: 0.75rem; color: #a1a1aa; margin-right: 4px; }
+    .tag.xhr { background: #1e3a5f; color: #60a5fa; }
+    .tag.http { background: #1e3a2f; color: #34d399; }
+    .tag.mock { background: #3b1e5f; color: #a78bfa; }
+    .flow-step { background: #1e1e2e; border-radius: 6px; padding: 16px; margin-bottom: 12px; border-left: 3px solid #4f46e5; }
+    .flow-step h4 { font-size: 0.875rem; margin-bottom: 8px; color: #fff; }
+    .flow-step p { font-size: 0.8rem; color: #71717a; line-height: 1.5; }
+    .input-group { margin-bottom: 12px; }
+    .input-group label { display: block; font-size: 0.75rem; color: #71717a; margin-bottom: 4px; }
+    .input-group input, .input-group select { width: 100%; padding: 8px 12px; background: #0f0f23; border: 1px solid #27272a; border-radius: 6px; color: #e4e4e7; font-size: 0.875rem; }
+    .input-group input:focus, .input-group select:focus { outline: none; border-color: #4f46e5; }
+  </style>
+</head>
+<body>
+  <h1>Axios Adapter 适配器模式</h1>
+  <p class="subtitle">理解 Axios 如何通过适配器接口实现跨环境 HTTP 请求</p>
+
+  <div class="tabs">
+    <button class="tab active" data-tab="pattern">适配器接口</button>
+    <button class="tab" data-tab="flow">请求流程</button>
+    <button class="tab" data-tab="custom">自定义适配器</button>
+    <button class="tab" data-tab="compare">方案对比</button>
+  </div>
+
+  <div class="panel">
+    <!-- 适配器接口 -->
+    <div id="panel-pattern" class="tab-content">
+      <div class="panel-section">
+        <h3>Adapter 接口定义</h3>
+        <div class="code-block"><span class="comment">// Axios 适配器接口 — 接收 config，返回 Promise</span>
+<span class="keyword">function</span> <span class="function">adapter</span>(<span class="param">config</span>) {
+  <span class="comment">// config 已完成合并、转换器、拦截器预处理</span>
+  <span class="comment">// 返回 Promise，resolve 时触发 response 转换器</span>
+  <span class="keyword">return</span> <span class="keyword">new</span> Promise(<span class="keyword">function</span>(<span class="param">resolve, reject</span>) {
+    <span class="comment">// 执行实际请求...</span>
+    <span class="keyword">const</span> response = {
+      data:       <span class="string">responseData</span>,
+      status:     <span class="param">request</span>.status,
+      statusText: <span class="param">request</span>.statusText,
+      headers:    <span class="param">responseHeaders</span>,
+      config:     <span class="param">config</span>,
+      request:    <span class="param">request</span>
+    };
+    <span class="comment">// settle 决定 resolve 或 reject</span>
+    settle(resolve, reject, response);
+  });
+}</div>
+      </div>
+
+      <div class="panel-section">
+        <h3>内置适配器映射</h3>
+        <div class="arrow-diagram">
+          <div class="arrow-step">
+            <div class="arrow-box primary">Axios(config)</div>
+            <span style="font-size:0.75rem;color:#71717a">发起请求</span>
+          </div>
+          <span class="arrow-arrow">→</span>
+          <div class="arrow-step">
+            <div class="arrow-box secondary">dispatchRequest</div>
+            <span style="font-size:0.75rem;color:#71717a">调度适配器</span>
+          </div>
+          <span class="arrow-arrow">→</span>
+          <div class="arrow-step">
+            <div class="arrow-box secondary">getAdapter()</div>
+            <span style="font-size:0.75rem;color:#71717a">选择适配器</span>
+          </div>
+          <span class="arrow-arrow">→</span>
+          <div class="arrow-step">
+            <div class="arrow-box secondary">adapter(config)</div>
+            <span style="font-size:0.75rem;color:#71717a">执行请求</span>
+          </div>
+        </div>
+        <div class="comparison-table">
+          <table>
+            <thead>
+              <tr><th>适配器</th><th>环境</th><th>实现</th><th>关键特性</th></tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td><span class="tag xhr">xhr</span></td>
+                <td>浏览器</td>
+                <td>XMLHttpRequest</td>
+                <td>上传/下载进度、请求取消、Cookie</td>
+              </tr>
+              <tr>
+                <td><span class="tag http">http</span></td>
+                <td>Node.js</td>
+                <td>http/https 模块</td>
+                <td>重定向、代理、HTTP/2、流式响应</td>
+              </tr>
+              <tr>
+                <td><span class="tag mock">mock</span></td>
+                <td>测试/开发</td>
+                <td>自定义</td>
+                <td>无网络延迟、可模拟错误</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+
+    <!-- 请求流程 -->
+    <div id="panel-flow" class="tab-content" style="display:none;">
+      <div class="panel-section">
+        <h3>XHR Adapter 请求流程（浏览器环境）</h3>
+        <div class="flow-step">
+          <h4>1. dispatchRequest(config)</h4>
+          <p>Axios 核心模块，合并默认配置与应用配置，运行请求转换器。</p>
+        </div>
+        <div class="flow-step">
+          <h4>2. getAdapter() 选择适配器</h4>
+          <p>根据环境判断：浏览器 → xhrAdapter，Node → httpAdapter。可通过 config.adapter 手动指定。</p>
+        </div>
+        <div class="flow-step">
+          <h4>3. xhrAdapter(config) 创建 Promise</h4>
+          <p>返回 Promise，异步执行 XMLHttpRequest。</p>
+        </div>
+        <div class="flow-step">
+          <h4>4. XMLHttpRequest.open()</h4>
+          <p>request.open(method, url, async) 建立连接。</p>
+        </div>
+        <div class="flow-step">
+          <h4>5. 设置请求头与选项</h4>
+          <p>setRequestHeader 设置自定义头，withCredentials 处理跨域 Cookie，responseType 指定响应格式。</p>
+        </div>
+        <div class="flow-step">
+          <h4>6. 注册事件处理器</h4>
+          <p>onloadend / onreadystatechange：响应完成；onabort：取消；onerror：网络错误；ontimeout：超时。</p>
+        </div>
+        <div class="flow-step">
+          <h4>7. request.send(data)</h4>
+          <p>发送请求，data 为请求体（FormData / JSON / 二进制）。</p>
+        </div>
+        <div class="flow-step">
+          <h4>8. settle(resolve, reject, response)</h4>
+          <p>根据 HTTP 状态码决定 Promise resolve 或 reject。2xx → resolve，其他 → reject。</p>
+        </div>
+        <div class="flow-step">
+          <h4>9. Response Interceptors</h4>
+          <p>响应拦截器处理 data 转换、错误标准化等。</p>
+        </div>
+      </div>
+
+      <div class="panel-section">
+        <h3>HTTP Adapter 请求流程（Node 环境）</h3>
+        <div class="flow-step">
+          <h4>1. buildFullPath() 构建完整路径</h4>
+          <p>合并 baseURL + url，处理绝对/相对路径。</p>
+        </div>
+        <div class="flow-step">
+          <h4>2. 数据流处理</h4>
+          <p>Buffer / ArrayBuffer / string → Buffer；FormData → stream；File/Blob → stream。</p>
+        </div>
+        <div class="flow-step">
+          <h4>3. http/https.request(options)</h4>
+          <p>创建 Node.js http(s) 请求，支持代理、重定向、超时。</p>
+        </div>
+        <div class="flow-step">
+          <h4>4. 进度与取消</h4>
+          <p>通过 EventEmitter 实现 abort 信号，可配合 AbortController 使用。</p>
+        </div>
+      </div>
+    </div>
+
+    <!-- 自定义适配器 -->
+    <div id="panel-custom" class="tab-content" style="display:none;">
+      <div class="grid-2">
+        <div class="panel-section">
+          <h3>自定义 Mock 适配器</h3>
+          <div class="code-block"><span class="comment">// mock-adapter.js — 模拟请求适配器</span>
+<span class="keyword">function</span> <span class="function">mockAdapter</span>(<span class="param">config</span>) {
+  <span class="keyword">return</span> <span class="keyword">new</span> Promise((<span class="param">resolve, reject</span>) => {
+    <span class="comment">// 模拟延迟</span>
+    setTimeout(() => {
+      <span class="keyword">const</span> response = {
+        data: { <span class="string">message</span>: <span class="string">'Mock 响应'</span>, config },
+        status: <span class="number">200</span>,
+        statusText: <span class="string">'OK'</span>,
+        headers: { <span class="string">'content-type'</span>: <span class="string">'application/json'</span> },
+        config,
+        request: <span class="keyword">null</span>
+      };
+      <span class="comment">// 模拟错误（config.forceError = true）</span>
+      <span class="keyword">if</span> (config.forceError) {
+        <span class="keyword">return</span> reject(<span class="keyword">new</span> Error(<span class="string">'Mock Error'</span>));
+      }
+      resolve(response);
+    }, config.delay || <span class="number">500</span>);
+  });
+}
+
+<span class="comment">// 使用方式</span>
+<span class="keyword">const</span> axios = <span class="function">require</span>(<span class="string">'axios'</span>);
+axios.defaults.adapter = mockAdapter;</div>
+        </div>
+      </div>
+
+      <div class="panel-section">
+        <h3>实际使用场景</h3>
+        <div class="comparison-table">
+          <table>
+            <thead>
+              <tr><th>场景</th><th>适配器实现</th><th>用途</th></tr>
+            </thead>
+            <tbody>
+              <tr><td>单元测试</td><td><span class="tag mock">Mock</span></td><td>无网络依赖，秒级完成</td></tr>
+              <tr><td>接口 Mock</td><td><span class="tag mock">Mock</span></td><td>前后端并行开发</td></tr>
+              <tr><td>跨端复用</td><td><span class="tag xhr">xhr</span></td><td>小程序/Uni-app 适配</td></tr>
+              <tr><td>调试代理</td><td><span class="tag xhr">xhr</span></td><td> Whistle / Charles 拦截</td></tr>
+              <tr><td>Service Worker</td><td><span class="tag http">http</span></td><td>离线缓存/网络优先</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div class="panel-section">
+        <h3>实战：自定义适配器实现请求重试</h3>
+        <div class="code-block"><span class="keyword">function</span> <span class="function">retryAdapter</span>(<span class="param">config</span>) {
+  <span class="keyword">const</span> maxRetries = config.retryCount || <span class="number">3</span>;
+  <span class="keyword">const</span> retryDelay = config.retryDelay || <span class="number">1000</span>;
+  <span class="keyword">const</span> originalAdapter = <span class="function">require</span>(<span class="string">'axios/lib/adapters/xhr'</span>);
+
+  <span class="keyword">function</span> <span class="function">attempt</span>(<span class="param">retryCount</span>) {
+    <span class="keyword">return</span> originalAdapter(config)
+      .catch(<span class="param">err</span> => {
+        <span class="keyword">if</span> (retryCount < maxRetries && isRetryableError(err)) {
+          <span class="keyword">return</span> <span class="keyword">new</span> Promise(<span class="function">resolve</span> => 
+            setTimeout(() => <span class="function">resolve</span>(<span class="function">attempt</span>(retryCount + <span class="number">1</span>)), retryDelay
+          ));
+        }
+        <span class="keyword">throw</span> err;
+      });
+  }
+
+  <span class="keyword">return</span> <span class="function">attempt</span>(<span class="number">0</span>);
+}
+
+<span class="comment">// 使用</span>
+axios.defaults.adapter = retryAdapter;</div>
+      </div>
+    </div>
+
+    <!-- 方案对比 -->
+    <div id="panel-compare" class="tab-content" style="display:none;">
+      <div class="panel-section">
+        <h3>Adapter vs Interceptor vs Transform</h3>
+        <div class="comparison-table">
+          <table>
+            <thead>
+              <tr><th>机制</th><th>作用层级</th><th>执行时机</th><th>适用场景</th></tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>Adapter</td>
+                <td>底层网络</td>
+                <td>最终请求发送</td>
+                <td>跨平台适配、Mock、调试拦截</td>
+              </tr>
+              <tr>
+                <td>Interceptor</td>
+                <td>请求/响应</td>
+                <td>请求前/响应后</td>
+                <td>统一 header、错误处理、日志</td>
+              </tr>
+              <tr>
+                <td>Transform</td>
+                <td>数据转换</td>
+                <td>请求序列化/响应反序列化</td>
+                <td>JSON 解析、格式转换</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div class="panel-section">
+        <h3>XHR vs Fetch vs http 模块</h3>
+        <div class="comparison-table">
+          <table>
+            <thead>
+              <tr><th>特性</th><th>XHR</th><th>Fetch</th><th>http 模块</th></tr>
+            </thead>
+            <tbody>
+              <tr><td>进度追踪</td><td><span class="success">✓ onprogress</span></td><td><span class="error">✗</span></td><td><span class="success">✓ stream</span></td></tr>
+              <tr><td>请求取消</td><td><span class="success">✓ abort</span></td><td><span class="success">✓ AbortController</span></td><td><span class="success">✓ destroy</span></td></tr>
+              <tr><td>超时控制</td><td><span class="success">✓ timeout</span></td><td><span class="error">需手写</span></td><td><span class="success">✓ setTimeout</span></td></tr>
+              <tr><td>跨域 Cookie</td><td><span class="success">✓ withCredentials</span></td><td><span class="success">✓ credentials</span></td><td><span class="error">N/A</span></td></tr>
+              <tr><td>代理支持</td><                <td><span class="error">需配置</span></td><td><span class="error">需手写</span></td><td><span class="success">✓ Agent</span></td></tr>
+              <tr><td>HTTP/2</td><td><span class="error">✗</span></td><td><span class="success">✓</span></td><td><span class="success">✓ http2</span></td></tr>
+              <tr><td>流式响应</td><td><span class="error">✗</span></td><td><span class="success">✓ ReadableStream</span></td><td><span class="success">✓ stream</span></td></tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div class="panel-section">
+        <h3>为什么需要适配器？</h3>
+        <div class="arrow-diagram" style="flex-direction:column;gap:8px;">
+          <div class="flow-step" style="margin:0;border-left-color:#4f46e5;">
+            <h4>同一套 API，多端运行</h4>
+            <p>Axios 代码可以在浏览器 (XMLHttpRequest)、Node.js (http 模块)、微信小程序、React Native 等环境运行，底层自动切换适配器。</p>
+          </div>
+          <div class="flow-step" style="margin:0;border-left-color:#4f46e5;">
+            <h4>可测试性</h4>
+            <p>通过 Mock 适配器，测试套件无需启动真实服务器，可模拟任意响应（成功/错误/超时）。</p>
+          </div>
+          <div class="flow-step" style="margin:0;border-left-color:#4f46e5;">
+            <h4>功能扩展</h4>
+            <p>请求重试、自动降级、调试拦截等横切关注点可通过自定义适配器统一注入。</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    // Tab switching
+    document.querySelectorAll('.tab').forEach(tab => {
+      tab.addEventListener('click', () => {
+        document.querySelectorAll('.tab').forEach(t => t.classList.remove('active'));
+        document.querySelectorAll('.tab-content').forEach(p => p.style.display = 'none');
+        tab.classList.add('active');
+        document.getElementById('panel-' + tab.dataset.tab).style.display = 'block';
+      });
+    });
+  </script>
+</body>
+</html>

--- a/examples/cors/multi-origin-demo.html
+++ b/examples/cors/multi-origin-demo.html
@@ -1,0 +1,815 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CORS 多域名 Access-Control-Allow-Origin 交互演示</title>
+    <style>
+        :root {
+            --primary: #6366f1;
+            --primary-dark: #4f46e5;
+            --primary-light: #818cf8;
+            --success: #10b981;
+            --success-light: #34d399;
+            --warning: #f59e0b;
+            --warning-light: #fbbf24;
+            --danger: #ef4444;
+            --danger-light: #f87171;
+            --bg-dark: #0f172a;
+            --bg-card: #1e293b;
+            --bg-card-hover: #273449;
+            --bg-input: #334155;
+            --text-primary: #f1f5f9;
+            --text-secondary: #94a3b8;
+            --text-muted: #64748b;
+            --border: #475569;
+            --border-light: #2d3748;
+        }
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+        body {
+            font-family: 'Segoe UI', system-ui, -apple-system, sans-serif;
+            background: var(--bg-dark);
+            color: var(--text-primary);
+            min-height: 100vh;
+            line-height: 1.7;
+            padding: 20px;
+        }
+        .container { max-width: 1100px; margin: 0 auto; }
+
+        header {
+            text-align: center;
+            padding: 35px 0 25px;
+            border-bottom: 1px solid var(--border-light);
+            margin-bottom: 30px;
+        }
+        .header-badge {
+            display: inline-block;
+            background: linear-gradient(135deg, var(--primary), var(--primary-light));
+            color: white;
+            padding: 4px 14px;
+            border-radius: 20px;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-bottom: 12px;
+            letter-spacing: 0.5px;
+        }
+        h1 {
+            font-size: 2rem;
+            font-weight: 800;
+            background: linear-gradient(135deg, var(--primary-light), var(--success-light));
+            -webkit-background-clip: text;
+            -webkit-text-fill-color: transparent;
+            background-clip: text;
+            margin-bottom: 10px;
+        }
+        .subtitle { color: var(--text-secondary); font-size: 1.05rem; }
+
+        .tab-nav {
+            display: flex;
+            gap: 8px;
+            flex-wrap: wrap;
+            margin-bottom: 25px;
+            background: var(--bg-card);
+            padding: 8px;
+            border-radius: 14px;
+            border: 1px solid var(--border-light);
+        }
+        .tab-btn {
+            flex: 1;
+            min-width: 120px;
+            padding: 12px 16px;
+            background: transparent;
+            border: none;
+            border-radius: 8px;
+            color: var(--text-secondary);
+            cursor: pointer;
+            font-size: 0.9rem;
+            font-weight: 600;
+            transition: all 0.25s;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: 6px;
+        }
+        .tab-btn:hover { background: var(--bg-input); color: var(--text-primary); }
+        .tab-btn.active {
+            background: var(--primary);
+            color: white;
+            box-shadow: 0 4px 12px rgba(99, 102, 241, 0.35);
+        }
+
+        .tab-content { display: none; }
+        .tab-content.active { display: block; animation: fadeIn 0.3s; }
+        @keyframes fadeIn { from { opacity: 0; transform: translateY(5px); } to { opacity: 1; transform: translateY(0); } }
+
+        .card {
+            background: var(--bg-card);
+            border: 1px solid var(--border-light);
+            border-radius: 14px;
+            padding: 26px;
+            margin-bottom: 20px;
+            transition: border-color 0.2s;
+        }
+        .card:hover { border-color: var(--border); }
+        .card-header { display: flex; align-items: center; gap: 10px; margin-bottom: 18px; }
+        .card-icon {
+            width: 40px;
+            height: 40px;
+            border-radius: 10px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-size: 1.3rem;
+            flex-shrink: 0;
+        }
+        .card-icon.blue { background: rgba(99, 102, 241, 0.15); }
+        .card-icon.green { background: rgba(16, 185, 129, 0.15); }
+        .card-icon.red { background: rgba(239, 68, 68, 0.15); }
+        .card-icon.yellow { background: rgba(245, 158, 11, 0.15); }
+        .card-icon.purple { background: rgba(168, 85, 247, 0.15); }
+        .card h2 { font-size: 1.25rem; font-weight: 700; color: var(--text-primary); }
+        .card p { color: var(--text-secondary); margin-bottom: 14px; font-size: 0.95rem; }
+        .card h3 { font-size: 1rem; color: var(--text-primary); margin: 20px 0 10px; font-weight: 600; }
+
+        .alert {
+            padding: 16px 18px;
+            border-radius: 10px;
+            margin: 14px 0;
+            font-size: 0.9rem;
+            display: flex;
+            gap: 10px;
+            align-items: flex-start;
+        }
+        .alert-icon { font-size: 1.1rem; flex-shrink: 0; margin-top: 2px; }
+        .alert-danger { background: rgba(239, 68, 68, 0.1); border: 1px solid rgba(239, 68, 68, 0.25); color: var(--danger-light); }
+        .alert-success { background: rgba(16, 185, 129, 0.1); border: 1px solid rgba(16, 185, 129, 0.25); color: var(--success-light); }
+        .alert-warning { background: rgba(245, 158, 11, 0.1); border: 1px solid rgba(245, 158, 11, 0.25); color: var(--warning-light); }
+        .alert-info { background: rgba(99, 102, 241, 0.1); border: 1px solid rgba(99, 102, 241, 0.25); color: var(--primary-light); }
+
+        .code-block { background: #0d1117; border-radius: 10px; margin: 14px 0; overflow: hidden; border: 1px solid var(--border-light); }
+        .code-header { background: var(--bg-input); padding: 9px 14px; display: flex; justify-content: space-between; align-items: center; border-bottom: 1px solid var(--border-light); }
+        .code-lang { color: var(--text-muted); font-size: 0.78rem; font-weight: 600; letter-spacing: 0.5px; text-transform: uppercase; }
+        .copy-btn { background: var(--primary); border: none; padding: 5px 12px; border-radius: 5px; color: white; cursor: pointer; font-size: 0.78rem; font-weight: 600; transition: background 0.2s; }
+        .copy-btn:hover { background: var(--primary-dark); }
+        .copy-btn.copied { background: var(--success); }
+        .code-content { padding: 14px 16px; overflow-x: auto; font-family: 'Cascadia Code', 'Fira Code', 'Consolas', monospace; font-size: 13px; line-height: 1.6; color: #e6edf3; }
+        .code-content .c { color: #8b949e; }
+        .code-content .k { color: #ff7b72; }
+        .code-content .s { color: #a5d6ff; }
+        .code-content .fn { color: #d2a8ff; }
+        .code-content .v { color: #ffa657; }
+        .code-content .n { color: #79c0ff; }
+
+        .data-table { width: 100%; border-collapse: collapse; margin: 12px 0; font-size: 0.9rem; border-radius: 8px; overflow: hidden; border: 1px solid var(--border-light); }
+        .data-table th { background: var(--bg-input); color: var(--text-primary); padding: 11px 14px; text-align: left; font-weight: 600; }
+        .data-table td { padding: 10px 14px; color: var(--text-secondary); border-top: 1px solid var(--border-light); }
+        .data-table tr:hover td { background: var(--bg-card-hover); }
+        .badge { display: inline-block; padding: 2px 8px; border-radius: 4px; font-size: 0.75rem; font-weight: 600; }
+        .badge-red { background: rgba(239, 68, 68, 0.15); color: var(--danger-light); }
+        .badge-green { background: rgba(16, 185, 129, 0.15); color: var(--success-light); }
+        .badge-yellow { background: rgba(245, 158, 11, 0.15); color: var(--warning-light); }
+        .badge-blue { background: rgba(99, 102, 241, 0.15); color: var(--primary-light); }
+
+        .flowchart { background: #0d1117; border-radius: 10px; padding: 20px; margin: 14px 0; border: 1px solid var(--border-light); overflow-x: auto; }
+        .flowchart svg { display: block; margin: 0 auto; max-width: 100%; }
+
+        .comparison-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; margin: 14px 0; }
+        @media (max-width: 600px) { .comparison-grid { grid-template-columns: 1fr; } }
+        .compare-box { background: var(--bg-input); border-radius: 10px; padding: 18px; border: 1px solid var(--border-light); }
+        .compare-box h4 { font-size: 0.95rem; margin-bottom: 10px; display: flex; align-items: center; gap: 6px; }
+        .compare-box.wrong h4 { color: var(--danger-light); }
+        .compare-box.right h4 { color: var(--success-light); }
+
+        .steps { counter-reset: step; }
+        .step { position: relative; padding: 14px 14px 14px 52px; margin-bottom: 10px; background: var(--bg-input); border-radius: 8px; font-size: 0.9rem; color: var(--text-secondary); border-left: 3px solid var(--primary); }
+        .step::before { counter-increment: step; content: counter(step); position: absolute; left: 12px; top: 14px; width: 28px; height: 28px; background: var(--primary); color: white; border-radius: 50%; display: flex; align-items: center; justify-content: center; font-size: 0.8rem; font-weight: 700; }
+
+        .interactive-panel { background: var(--bg-input); border-radius: 10px; padding: 20px; margin: 14px 0; border: 1px solid var(--border-light); }
+        .interactive-panel label { display: block; font-size: 0.85rem; color: var(--text-secondary); margin-bottom: 6px; font-weight: 600; }
+        .origin-selector { display: flex; gap: 8px; flex-wrap: wrap; margin-bottom: 14px; }
+        .origin-chip { padding: 7px 14px; background: var(--bg-card); border: 1px solid var(--border); border-radius: 6px; cursor: pointer; font-size: 0.85rem; color: var(--text-secondary); transition: all 0.2s; }
+        .origin-chip:hover { border-color: var(--primary); color: var(--text-primary); }
+        .origin-chip.selected { background: var(--primary); border-color: var(--primary); color: white; }
+        .test-result { margin-top: 14px; padding: 14px; border-radius: 8px; font-size: 0.88rem; display: none; }
+        .test-result.show { display: block; }
+        .test-result.success { background: rgba(16, 185, 129, 0.1); border: 1px solid rgba(16, 185, 129, 0.25); color: var(--success-light); }
+        .test-result.error { background: rgba(239, 68, 68, 0.1); border: 1px solid rgba(239, 68, 68, 0.25); color: var(--danger-light); }
+        .test-result pre { margin-top: 8px; font-family: 'Cascadia Code', monospace; font-size: 0.82rem; color: var(--text-secondary); white-space: pre-wrap; word-break: break-all; }
+
+        .run-btn { display: inline-flex; align-items: center; gap: 6px; background: linear-gradient(135deg, var(--primary), var(--primary-dark)); color: white; border: none; padding: 10px 22px; border-radius: 8px; cursor: pointer; font-size: 0.9rem; font-weight: 600; transition: all 0.2s; margin-top: 12px; }
+        .run-btn:hover { transform: translateY(-1px); box-shadow: 0 4px 14px rgba(99, 102, 241, 0.4); }
+
+        .scenario-list { display: flex; flex-direction: column; gap: 10px; margin: 10px 0; }
+        .scenario-card { background: var(--bg-input); border-radius: 8px; padding: 14px; border-left: 3px solid var(--border); transition: border-color 0.2s; }
+        .scenario-card:hover { border-left-color: var(--primary); }
+        .scenario-card h4 { font-size: 0.9rem; color: var(--text-primary); margin-bottom: 6px; }
+        .scenario-card p { font-size: 0.83rem; color: var(--text-secondary); margin: 0; }
+        .scenario-card .badge { margin-top: 6px; }
+
+        footer { text-align: center; padding: 25px 0; color: var(--text-muted); font-size: 0.82rem; border-top: 1px solid var(--border-light); margin-top: 30px; }
+        footer a { color: var(--primary-light); text-decoration: none; }
+        footer a:hover { text-decoration: underline; }
+
+        @media (max-width: 768px) {
+            h1 { font-size: 1.5rem; }
+            .tab-btn { min-width: 100px; font-size: 0.82rem; padding: 10px 12px; }
+            .card { padding: 18px; }
+        }
+
+        code { background: var(--bg-input); padding: 2px 6px; border-radius: 4px; font-family: 'Cascadia Code', monospace; font-size: 0.88em; color: var(--primary-light); }
+    </style>
+</head>
+<body>
+<div class="container">
+
+<header>
+    <div class="header-badge">CORS 核心机制</div>
+    <h1>多个 Access-Control-Allow-Origin<br>为什么不会报错？</h1>
+    <p class="subtitle">规范允许 ≠ 浏览器支持，深入理解 CORS 的规范与实现差异</p>
+</header>
+
+<nav class="tab-nav">
+    <button class="tab-btn active" onclick="switchTab('overview')"><span class="tab-btn">📖</span> 概述</button>
+    <button class="tab-btn" onclick="switchTab('spec')"><span class="tab-btn">📜</span> 规范 vs 实现</button>
+    <button class="tab-btn" onclick="switchTab('dynamic')"><span class="tab-btn">⚙️</span> 动态 Origin</button>
+    <button class="tab-btn" onclick="switchTab('errors')"><span class="tab-btn">🚨</span> 常见错误</button>
+</nav>
+
+<!-- ========== TAB 1: Overview ========== -->
+<div id="tab-overview" class="tab-content active">
+    <div class="card">
+        <div class="card-header">
+            <div class="card-icon blue">⚡</div>
+            <h2>核心结论</h2>
+        </div>
+        <div class="alert alert-danger">
+            <span class="alert-icon">🚫</span>
+            <div><strong>CORS 规范允许</strong>服务器返回多个 <code>Access-Control-Allow-Origin</code> 值，但<strong>没有任何浏览器支持此行为</strong>。如果服务器尝试这样做，浏览器会直接报错。</div>
+        </div>
+        <div class="alert alert-warning">
+            <span class="alert-icon">⚠️</span>
+            <div>报错信息：<code>Multiple CORS header Access-Control-Allow-Origin not allowed</code></div>
+        </div>
+        <p>记住这个原则：<strong>CORS 是浏览器的安全策略，规范只是纸面约定，浏览器实现才是真相。</strong></p>
+    </div>
+
+    <div class="card">
+        <div class="card-header">
+            <div class="card-icon green">🔍</div>
+            <h2>问题本质图解</h2>
+        </div>
+        <div class="flowchart">
+            <svg width="680" height="300" viewBox="0 0 680 300">
+                <!-- Title -->
+                <text x="340" y="18" text-anchor="middle" fill="#64748b" font-size="11" font-weight="600">服务器返回多个 ACAO 头部时，浏览器的处理流程</text>
+
+                <!-- Server -->
+                <rect x="10" y="45" width="140" height="75" rx="8" fill="#1e293b" stroke="#6366f1" stroke-width="2"/>
+                <text x="80" y="72" text-anchor="middle" fill="#e6edf3" font-size="13" font-weight="600">服务器</text>
+                <text x="80" y="90" text-anchor="middle" fill="#94a3b8" font-size="10">返回响应 +</text>
+                <text x="80" y="104" text-anchor="middle" fill="#94a3b8" font-size="10">多个 ACAO 头部</text>
+                <text x="80" y="118" text-anchor="middle" fill="#6366f1" font-size="10">"a.com", "b.com"</text>
+
+                <!-- Arrow -->
+                <line x1="150" y1="82" x2="190" y2="82" stroke="#475569" stroke-width="2" marker-end="url(#arr)"/>
+                <defs><marker id="arr" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#475569"/></marker></defs>
+
+                <!-- Browser box -->
+                <rect x="195" y="35" width="180" height="130" rx="8" fill="#1e293b" stroke="#f59e0b" stroke-width="2"/>
+                <text x="285" y="58" text-anchor="middle" fill="#e6edf3" font-size="13" font-weight="600">浏览器 CORS 检查</text>
+
+                <!-- Check inside browser -->
+                <rect x="208" y="68" width="154" height="85" rx="5" fill="#0d1117" stroke="#f59e0b" stroke-width="1.5"/>
+                <text x="285" y="90" text-anchor="middle" fill="#fbbf24" font-size="11" font-weight="600">ACAO 头部数量</text>
+                <text x="285" y="108" text-anchor="middle" fill="#94a3b8" font-size="10">＝ 1 → 检查值是否匹配</text>
+                <text x="285" y="123" text-anchor="middle" fill="#94a3b8" font-size="10">＝ 0 → 缺少必需头部</text>
+                <text x="285" y="138" text-anchor="middle" fill="#ef4444" font-size="10" font-weight="600">＞ 1 → 报错拒绝</text>
+
+                <!-- Arrow to Error -->
+                <line x1="375" y1="82" x2="420" y2="82" stroke="#ef4444" stroke-width="2" marker-end="url(#arrRed)"/>
+                <defs><marker id="arrRed" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#ef4444"/></marker></defs>
+
+                <!-- Error -->
+                <rect x="425" y="42" width="210" height="80" rx="8" fill="#1e293b" stroke="#ef4444" stroke-width="2"/>
+                <text x="530" y="70" text-anchor="middle" fill="#ef4444" font-size="13" font-weight="700">❌ CORS Error</text>
+                <text x="530" y="88" text-anchor="middle" fill="#f87171" font-size="10">Multiple CORS header</text>
+                <text x="530" y="102" text-anchor="middle" fill="#f87171" font-size="10">Access-Control-Allow-Origin</text>
+                <text x="530" y="116" text-anchor="middle" fill="#f87171" font-size="10">not allowed</text>
+
+                <!-- Legend -->
+                <rect x="10" y="195" width="12" height="12" rx="2" fill="#6366f1"/>
+                <text x="28" y="205" fill="#64748b" font-size="10">服务器响应</text>
+                <rect x="120" y="195" width="12" height="12" rx="2" fill="#f59e0b"/>
+                <text x="138" y="205" fill="#64748b" font-size="10">浏览器检查</text>
+                <rect x="220" y="195" width="12" height="12" rx="2" fill="#ef4444"/>
+                <text x="238" y="205" fill="#64748b" font-size="10">报错拒绝</text>
+
+                <!-- Key insight box -->
+                <rect x="10" y="225" width="660" height="55" rx="8" fill="rgba(99,102,241,0.08)" stroke="rgba(99,102,241,0.3)" stroke-width="1.5"/>
+                <text x="340" y="248" text-anchor="middle" fill="#818cf8" font-size="11" font-weight="600">💡 关键洞察</text>
+                <text x="340" y="268" text-anchor="middle" fill="#94a3b8" font-size="10">即使服务器返回了多个值，浏览器也只关心「有几个」——多值 = 直接拒绝，不管值本身是否正确</text>
+            </svg>
+        </div>
+    </div>
+
+    <div class="card">
+        <div class="card-header">
+            <div class="card-icon purple">📊</div>
+            <h2>快速对照表</h2>
+        </div>
+        <table class="data-table">
+            <thead>
+                <tr>
+                    <th>ACAO 值</th>
+                    <th>需要凭证?</th>
+                    <th>支持情况</th>
+                    <th>适用场景</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr><td><code>*</code></td><td>❌ 不能</td><td><span class="badge badge-green">✅ 全部支持</span></td><td>公开跨域资源（CDN、公共 API）</td></tr>
+                <tr><td><code>https://example.com</code></td><td>✅ 可以</td><td><span class="badge badge-green">✅ 全部支持</span></td><td>单域名、受信任来源</td></tr>
+                <tr><td><code>null</code></td><td>⚠️ 危险</td><td><span class="badge badge-yellow">⚠️ 支持但不推荐</span></td><td>本地 file://、特殊场景</td></tr>
+                <tr><td><code>a.com, b.com</code></td><td>—</td><td><span class="badge badge-red">❌ 全部报错</span></td><td>无（规范未定义）</td></tr>
+                <tr><td>多个 ACAO 头部</td><td>—</td><td><span class="badge badge-red">❌ 全部报错</span></td><td>无（浏览器直接拒绝）</td></tr>
+            </tbody>
+        </table>
+    </div>
+</div>
+
+<!-- ========== TAB 2: Spec vs Implementation ========== -->
+<div id="tab-spec" class="tab-content">
+    <div class="card">
+        <div class="card-header">
+            <div class="card-icon blue">📜</div>
+            <h2>CORS 规范说了什么？</h2>
+        </div>
+        <p>根据 Fetch 标准（WHATWG）和 W3C CORS 规范，`Access-Control-Allow-Origin` 的语法定义为：</p>
+        <div class="code-block">
+            <div class="code-header"><span class="code-lang">ABNF</span></div>
+            <div class="code-content">
+<span class="c"># Access-Control-Allow-Origin 语法（Fetch 标准）</span>
+Access-Control-Allow-Origin = <span class="v">origin-or-null</span> / <span class="s">"*"</span>
+
+<span class="c"># 规范允许的值：</span>
+<span class="c"># 1. 单个 origin：  https://example.com</span>
+<span class="c"># 2. null：        null</span>
+<span class="c"># 3. 通配符：      *</span>
+
+<span class="c"># ⚠️ 规范从未定义「多个 origin」的表示语法</span>
+            </div>
+        </div>
+        <div class="alert alert-info">
+            <span class="alert-icon">ℹ️</span>
+            <div>规范允许：单 origin 值、`null`、或通配符 <code>*</code>。<strong>规范没有定义多值的表示语法</strong>，但也没有明确禁止「多个头部」的情况。</div>
+        </div>
+    </div>
+
+    <div class="card">
+        <div class="card-header">
+            <div class="card-icon red">🌐</div>
+            <h2>浏览器实际做了什么？</h2>
+        </div>
+        <p>尽管规范「模棱两可」，但所有浏览器厂商都选择了同一条路：<strong>只支持单值</strong>。</p>
+        <table class="data-table">
+            <thead>
+                <tr><th>浏览器</th><th>支持多 ACAO 头部？</th><th>多值（a.com, b.com）？</th><th>错误信息</th></tr>
+            </thead>
+            <tbody>
+                <tr><td>Chrome / Edge</td><td><span class="badge badge-red">❌ 不支持</span></td><td><span class="badge badge-red">❌ 不支持</span></td><td>Multiple CORS header not allowed</td></tr>
+                <tr><td>Firefox</td><td><span class="badge badge-red">❌ 不支持</span></td><td><span class="badge badge-red">❌ 不支持</span></td><td>has more than one value...</td></tr>
+                <tr><td>Safari</td><td><span class="badge badge-red">❌ 不支持</span></td><td><span class="badge badge-red">❌ 不支持</span></td><td>Multiple headers not allowed</td></tr>
+            </tbody>
+        </table>
+    </div>
+
+    <div class="card">
+        <div class="card-header">
+            <div class="card-icon yellow">🤔</div>
+            <h2>为什么浏览器不能支持多值？</h2>
+        </div>
+        <div class="comparison-grid">
+            <div class="compare-box">
+                <h4>❌ CORS 需要明确性</h4>
+                <p>浏览器的安全策略需要二元答案：<code>"这个响应允不允许当前 origin?"</code></p>
+                <p style="margin-top:6px">如果允许多值，浏览器无法给出确定答案。</p>
+            </div>
+            <div class="compare-box">
+                <h4>❌ 凭证（Credentials）冲突</h4>
+                <p>带凭证请求时，ACAO 必须精确匹配请求 origin，或使用 <code>*</code>（但 <code>*</code> 不能与凭证同用）</p>
+                <p style="margin-top:6px">多值无法满足这一要求。</p>
+            </div>
+            <div class="compare-box">
+                <h4>❌ 语法歧义</h4>
+                <p>「多个 origin」可以有多种表示方法：逗号分隔？空格分隔？重复头部？</p>
+                <p style="margin-top:6px">规范没有定义，浏览器无法统一实现。</p>
+            </div>
+            <div class="compare-box">
+                <h4>❌ 安全最小化原则</h4>
+                <p>安全策略应遵循最小权限原则：</p>
+                <p style="margin-top:6px">只允许明确指定的来源，而非模糊的「某些来源」。多值会扩大攻击面。</p>
+            </div>
+        </div>
+    </div>
+
+    <div class="card">
+        <div class="card-header">
+            <div class="card-icon green">🔀</div>
+            <h2>浏览器 CORS 检查完整流程图</h2>
+        </div>
+        <div class="flowchart">
+            <svg width="650" height="430" viewBox="0 0 650 430">
+                <!-- Start -->
+                <ellipse cx="325" cy="22" rx="80" ry="22" fill="#6366f1"/>
+                <text x="325" y="27" text-anchor="middle" fill="white" font-size="12" font-weight="600">浏览器收到跨域响应</text>
+
+                <!-- Step 1: Has ACAO? -->
+                <line x1="325" y1="44" x2="325" y2="65" stroke="#475569" stroke-width="2" marker-end="url(#a2)"/>
+                <rect x="155" y="68" width="340" height="55" rx="8" fill="#1e293b" stroke="#f59e0b" stroke-width="2"/>
+                <text x="325" y="90" text-anchor="middle" fill="#fbbf24" font-size="12" font-weight="600">① Access-Control-Allow-Origin 头部存在？</text>
+                <text x="325" y="107" text-anchor="middle" fill="#94a3b8" font-size="10">检查响应是否包含该头部</text>
+
+                <!-- No branch -->
+                <line x1="155" y1="95" x2="50" y2="95" stroke="#ef4444" stroke-width="2" marker-end="url(#aR)"/>
+                <rect x="10" y="75" width="70" height="40" rx="6" fill="#1e293b" stroke="#ef4444" stroke-width="2"/>
+                <text x="45" y="100" text-anchor="middle" fill="#ef4444" font-size="11" font-weight="700">拒绝</text>
+
+                <!-- Yes arrow to Q2 -->
+                <line x1="495" y1="95" x2="580" y2="95" stroke="#10b981" stroke-width="2" marker-end="url(#aG)"/>
+
+                <!-- Step 2: How many values -->
+                <rect x="420" y="68" width="220" height="55" rx="8" fill="#1e293b" stroke="#10b981" stroke-width="2"/>
+                <text x="530" y="90" text-anchor="middle" fill="#34d399" font-size="12" font-weight="600">② 头部数量？</text>
+                <text x="530" y="107" text-anchor="middle" fill="#94a3b8" font-size="10">0 / 1 / 多个</text>
+
+                <!-- Back down -->
+                <line x1="530" y1="123" x2="530" y2="145" stroke="#475569" stroke-width="2" marker-end="url(#a2)"/>
+
+                <!-- Step 3: Decision -->
+                <rect x="405" y="148" width="250" height="90" rx="8" fill="#1e293b" stroke="#475569" stroke-width="2"/>
+                <text x="530" y="170" text-anchor="middle" fill="#e6edf3" font-size="12" font-weight="600">③ 检查 Access-Control-Allow-Origin 值</text>
+                <text x="530" y="188" text-anchor="middle" fill="#94a3b8" font-size="10">数量 = 0 → 拒绝（缺少必需头部）</text>
+                <text x="530" y="202" text-anchor="middle" fill="#94a3b8" font-size="10">数量 = 1 → 检查值</text>
+                <text x="530" y="216" text-anchor="middle" fill="#f87171" font-size="10">数量 > 1 → 报错（Multiple not allowed）</text>
+
+                <!-- Value check arrow -->
+                <line x1="530" y1="238" x2="530" y2="260" stroke="#475569" stroke-width="2" marker-end="url(#a2)"/>
+
+                <!-- Step 4: Value match -->
+                <rect x="390" y="263" width="280" height="90" rx="8" fill="#1e293b" stroke="#475569" stroke
+-width="2"/>
+                <text x="530" y="285" text-anchor="middle" fill="#e6edf3" font-size="12" font-weight="600">鈶?鍊兼槸鍚︾嚎鍖?</text>
+                <text x="530" y="303" text-anchor="middle" fill="#94a3b8" font-size="10">ACAO = * 銆嶱ACAO = 璇锋眰 Origin</text>
+                <text x="530" y="318" text-anchor="middle" fill="#94a3b8" font-size="10">甯﹀～璇佸悧锛?/text>
+
+                <!-- Match/No-Match arrows -->
+                <line x1="390" y1="305" x2="220" y2="305" stroke="#10b981" stroke-width="2" marker-end="url(#aG)"/>
+                <line x1="670" y1="305" x2="600" y2="305" stroke="#ef4444" stroke-width="2" marker-end="url(#aR)"/>
+
+                <!-- Match: Allow -->
+                <rect x="120" y="280" width="180" height="50" rx="8" fill="#1e293b" stroke="#10b981" stroke-width="2"/>
+                <text x="210" y="303" text-anchor="middle" fill="#34d399" font-size="13" font-weight="700">鍏佸紑 + 鍝嶅簲</text>
+                <text x="210" y="320" text-anchor="middle" fill="#10b981" font-size="10">JS 鑾峰彇鍝嶅簲鏁版嵁</text>
+
+                <!-- No Match: Block -->
+                <rect x="600" y="280" width="40" height="50" rx="8" fill="#1e293b" stroke="#ef4444" stroke-width="2"/>
+                <text x="620" y="310" text-anchor="middle" fill="#ef4444" font-size="10" font-weight="700">鎷掔粷</text>
+
+                <!-- Defs -->
+                <defs>
+                    <marker id="a2" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#475569"/></marker>
+                    <marker id="aR" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#ef4444"/></marker>
+                    <marker id="aG" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#10b981"/></marker>
+                </defs>
+
+                <!-- Step labels -->
+                <text x="12" y="68" fill="#6366f1" font-size="9" font-weight="600">Step 1</text>
+                <text x="600" y="68" fill="#6366f1" font-size="9" font-weight="600">Step 2</text>
+                <text x="555" y="148" fill="#6366f1" font-size="9" font-weight="600">Step 3</text>
+                <text x="545" y="263" fill="#6366f1" font-size="9" font-weight="600">Step 4</text>
+            </svg>
+        </div>
+    </div>
+</div>
+
+<!-- ========== TAB 3: Dynamic Origin ========== -->
+<div id="tab-dynamic" class="tab-content">
+    <div class="card">
+        <div class="card-header">
+            <div class="card-icon green">⚙️</div>
+            <h2>正确做法：动态回显 Origin</h2>
+        </div>
+        <p>服务器不应该硬编码多个 origin，而是：<strong>检查请求的 Origin 是否在白名单中，如果是，原样返回该 Origin</strong>。</p>
+        <div class="flowchart">
+            <svg width="650" height="200" viewBox="0 0 650 200">
+                <!-- Step 1 -->
+                <rect x="10" y="50" width="160" height="90" rx="8" fill="#1e293b" stroke="#6366f1" stroke-width="2"/>
+                <text x="90" y="80" text-anchor="middle" fill="#e6edf3" font-size="12" font-weight="600">1. 收到请求</text>
+                <text x="90" y="100" text-anchor="middle" fill="#94a3b8" font-size="10">Origin: https://a.com</text>
+                <text x="90" y="118" text-anchor="middle" fill="#94a3b8" font-size="10">GET /api/data</text>
+
+                <line x1="170" y1="95" x2="210" y2="95" stroke="#475569" stroke-width="2" marker-end="url(#a3)"/>
+                <defs><marker id="a3" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#475569"/></marker></defs>
+
+                <!-- Step 2 -->
+                <rect x="215" y="50" width="160" height="90" rx="8" fill="#1e293b" stroke="#f59e0b" stroke-width="2"/>
+                <text x="295" y="80" text-anchor="middle" fill="#e6edf3" font-size="12" font-weight="600">2. 检查白名单</text>
+                <text x="295" y="100" text-anchor="middle" fill="#94a3b8" font-size="10">["a.com","b.com","c.com"]</text>
+                <text x="295" y="118" text-anchor="middle" fill="#fbbf24" font-size="10">https://a.com 鍦ㄥ簭鍒楀垽?</text>
+
+                <line x1="375" y1="95" x2="415" y2="95" stroke="#475569" stroke-width="2" marker-end="url(#a3)"/>
+
+                <!-- Step 3 -->
+                <rect x="420" y="50" width="160" height="90" rx="8" fill="#1e293b" stroke="#10b981" stroke-width="2"/>
+                <text x="500" y="80" text-anchor="middle" fill="#e6edf3" font-size="12" font-weight="600">3. 回显 Origin</text>
+                <text x="500" y="100" text-anchor="middle" fill="#34d399" font-size="10">ACAO: https://a.com</text>
+                <text x="500" y="118" text-anchor="middle" fill="#34d399" font-size="10">ACA-Credentials: true</text>
+
+                <line x1="580" y1="95" x2="620" y2="95" stroke="#475569" stroke-width="2" marker-end="url(#a3)"/>
+
+                <!-- Step 4 -->
+                <rect x="485" y="50" width="150" height="90" rx="8" fill="#1e293b" stroke="#10b981" stroke-width="2"/>
+                <text x="560" y="80" text-anchor="middle" fill="#34d399" font-size="12" font-weight="700">✅ 成功</text>
+                <text x="560" y="100" text-anchor="middle" fill="#94a3b8" font-size="10">娴忚鍣ㄥ厑璁?/text>
+                <text x="560" y="118" text-anchor="middle" fill="#94a3b8" font-size="10">JS 鑾峰彇鏁版嵁</text>
+            </svg>
+        </div>
+
+        <div class="alert alert-success">
+            <span class="alert-icon">✅</span>
+            <div>动态回显的核心：<strong>响应中的 ACAO 值精确匹配请求的 Origin</strong>，而非硬编码列表。浏览器看到「你是谁，我就信任谁」，而非「我信任的是这些人」。</div>
+        </div>
+    </div>
+
+    <div class="card">
+        <div class="card-header">
+            <div class="card-icon blue">⌨️</div>
+            <h2>代码示例</h2>
+        </div>
+
+        <h3>Node.js / Express</h3>
+        <div class="code-block">
+            <div class="code-header">
+                <span class="code-lang">JavaScript</span>
+                <button class="copy-btn" onclick="copyCode(this)">复制</button>
+            </div>
+            <div class="code-content"><span class="k">const</span> allowedOrigins = [
+  <span class="s">"https://a.com"</span>,
+  <span class="k">"https://b.com"</span>,
+  <span class="s">"https://c.com"</span>
+];
+
+app.<span class="fn">use</span>((req, res, next) => {
+  <span class="k">const</span> origin = req.headers.origin;
+  
+  <span class="k">if</span> (allowedOrigins.<span class="fn">includes</span>(origin)) {
+    res.<span class="fn">setHeader</span>(<span class="s">"Access-Control-Allow-Origin"</span>, origin);
+    res.<span class="fn">setHeader</span>(<span class="s">"Access-Control-Allow-Credentials"</span>, <span class="s">"true"</span>);
+    res.<span class="fn">setHeader</span>(<span class="s">"Access-Control-Allow-Methods"</span>, <span class="s">"GET, POST, PUT, DELETE"</span>);
+    res.<span class="fn">setHeader</span>(<span class="s">"Access-Control-Allow-Headers"</span>, <span class="s">"Content-Type, Authorization"</span>);
+  }
+  
+  next();
+});</div>
+        </div>
+
+        <h3>Nginx（使用 map）</h3>
+        <div class="code-block">
+            <div class="code-header">
+                <span class="code-lang">Nginx</span>
+                <button class="copy-btn" onclick="copyCode(this)">复制</button>
+            </div>
+            <div class="code-content"><span class="c"># http 块中定义</span>
+<span class="k">map</span> $http_origin $cors_origin {
+    <span class="s">"~^https://(a|b|c)\.com$"</span>  $http_origin;
+    <span class="k">default</span> <span class="s">""</span>;
+}
+
+server {
+    location /api/ {
+        <span class="fn">add_header</span> <span class="s">Access-Control-Allow-Origin</span> $cors_origin;
+        <span class="fn">add_header</span> <span class="s">Access-Control-Allow-Credentials</span> <span class="s">"true"</span>;
+        <span class="fn">add_header</span> <span class="s">Access-Control-Allow-Methods</span> <span class="s">"GET, POST, PUT, DELETE"</span>;
+        <span class="fn">add_header</span> <span class="s">Access-Control-Allow-Headers</span> <span class="s">"Content-Type, Authorization"</span>;
+    }
+}</div>
+        </div>
+
+        <h3>Python / Flask</h3>
+        <div class="code-block">
+            <div class="code-header">
+                <span class="code-lang">Python</span>
+                <button class="copy-btn" onclick="copyCode(this)">复制</button>
+            </div>
+            <div class="code-content">ALLOWED_ORIGINS = [
+    <span class="s">"https://a.com"</span>,
+    <span class="s">"https://b.com"</span>,
+    <span class="s">"https://c.com"</span>
+]
+
+<span class="k">@app.after_request</span>
+<span class="k">def</span> <span class="fn">add_cors_headers</span>(response):
+    origin = request.headers.<span class="fn">get</span>(<span class="s">"Origin"</span>)
+    
+    <span class="k">if</span> origin <span class="k">in</span> ALLOWED_ORIGINS:
+        response.headers[<span class="s">"Access-Control-Allow-Origin"</span>] = origin
+        response.headers[<span class="s">"Access-Control-Allow-Credentials"</span>] = <span class="s">"true"</span>
+        response.headers[<span class="s">"Access-Control-Allow-Methods"</span>] = <span class="s">"GET, POST, PUT, DELETE"</span>
+        response.headers[<span class="s">"Access-Control-Allow-Headers"</span>] = <span class="s">"Content-Type, Authorization"</span>
+    
+    <span class="k">return</span> response</div>
+        </div>
+    </div>
+
+    <div class="card">
+        <div class="card-header">
+            <div class="card-icon purple">🎮</div>
+            <h2>交互演示：模拟动态 Origin 检查</h2>
+        </div>
+        <p>点击不同的请求来源，观察服务器的响应行为：</p>
+        <div class="interactive-panel">
+            <label>选择发起请求的来源：</label>
+            <div class="origin-selector">
+                <span class="origin-chip" onclick="selectOrigin(this, 'https://a.com')">https://a.com</span>
+                <span class="origin-chip" onclick="selectOrigin(this, 'https://b.com')">https://b.com</span>
+                <span class="origin-chip" onclick="selectOrigin(this, 'https://evil.com')">https://evil.com</span>
+                <span class="origin-chip" onclick="selectOrigin(this, 'null')">null (本地文件)</span>
+            </div>
+            <label>服务器白名单：["https://a.com", "https://b.com", "https://c.com"]</label>
+            <button class="run-btn" onclick="runSimulation()">▶ 运行模拟</button>
+            <div id="test-result" class="test-result"></div>
+        </div>
+    </div>
+</div>
+
+<!-- ========== TAB 4: Common Errors ========== -->
+<div id="tab-errors" class="tab-content">
+    <div class="card">
+        <div class="card-header">
+            <div class="card-icon red">🚨</div>
+            <h2>常见错误配置</h2>
+        </div>
+        <div class="scenario-list">
+            <div class="scenario-card">
+                <h4>❌ Nginx 配置逗号分隔多个 origin</h4>
+                <p>尝试用逗号分隔多个域名，以为这样可以允许多个来源。</p>
+                <span class="badge badge-red">浏览器报错</span>
+                <div class="code-block" style="margin-top:10px">
+                    <div class="code-header"><span class="code-lang">Nginx</span></div>
+                    <div class="code-content"><span class="fn">add_header</span> <span class="s">Access-Control-Allow-Origin</span> <span class="s">"https://a.com,https://b.com"</span>;</div>
+                </div>
+            </div>
+            <div class="scenario-card">
+                <h4>❌ 重复设置多个 ACAO 头部</h4>
+                <p>以为设置多个 add_header 行可以「叠加」效果，实际只有最后一个生效。</p>
+                <span class="badge badge-red">浏览器报错</span>
+                <div class="code-block" style="margin-top:10px">
+                    <div class="code-header"><span class="code-lang">Nginx</span></div>
+                    <div class="code-content"><span class="fn">add_header</span> <span class="s">Access-Control-Allow-Origin</span> <span class="s">"https://a.com"</span>;
+<span class="fn">add_header</span> <span class="s">Access-Control-Allow-Origin</span> <span class="s">"https://b.com"</span>;</div>
+                </div>
+            </div>
+            <div class="scenario-card">
+                <h4>❌ 同时返回 * 和具体 origin</h4>
+                <p>想同时支持公开访问和特定域名，但带凭证请求时这会导致浏览器拒绝。</p>
+                <span class="badge badge-red">浏览器拒绝</span>
+                <div class="code-block" style="margin-top:10px">
+                    <div class="code-header"><span class="code-lang">Nginx</span></div>
+                    <div class="code-content"><span class="fn">add_header</span> <span class="s">Access-Control-Allow-Origin</span> <span class="s">"*"</span>;
+<span class="fn">add_header</span> <span class="s">Access-Control-Allow-Origin"</span> <span class="s">"https://a.com"</span>;</div>
+                </div>
+            </div>
+            <div class="scenario-card">
+                <h4>❌ Express.js 中用 append 添加多个头部</h4>
+                <p>Node.js 的 res.append() 会在已有头部存在时创建多个头部，导致浏览器报错。</p>
+                <span class="badge badge-red">浏览器报错</span>
+                <div class="code-block" style="margin-top:10px">
+                    <div class="code-header"><span class="code-lang">JavaScript</span></div>
+                    <div class="code-content">res.<span class="fn">append</span>(<span class="s">"Access-Control-Allow-Origin"</span>, <span class="s">"https://a.com"</span>);
+res.<span class="fn">append</span>(<span class="s">"Access-Control-Allow-Origin"</span>, <span class="s">"https://b.com"</span>);
+<span class="c">// 实际产生多个头部 鈫?浏览器报错</span></div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="card">
+        <div class="card-header">
+            <div class="card-icon yellow">⚠️</div>
+            <h2>其他需要注意的场景</h2>
+        </div>
+        <div class="scenario-list">
+            <div class="scenario-card">
+                <h4>⚠️ CDN 多域名配置</h4>
+                <p>CDN 配置面板允许添加多个 origin，但 CDN 对外只返回一个 ACAO。如果 CDN 内部实现产生了多个头部，源站也会收到错误。</p>
+                <span class="badge badge-yellow">配置风险</span>
+            </div>
+            <div class="scenario-card">
+                <h4>⚠️ 允许 null origin</h4>
+                <p>如果服务器返回 ACAO: null，会允许来自 file:// 协议、iframe 等的请求，可能导致安全风险。</p>
+                <span class="badge badge-yellow">安全风险</span>
+            </div>
+            <div class="scenario-card">
+                <h4>⚠️ CORS 与重定向</h4>
+                <p>跨域重定向后，Origin 可能变为 null 或目标域。需要在重定向目标也正确配置 CORS 头部。</p>
+                <span class="badge badge-yellow">容易遗漏</span>
+            </div>
+            <div class="scenario-card">
+                <h4>⚠️ Vary: Origin 头部</h4>
+                <p>使用动态回显时，响应头应包含 Vary: Origin，让缓存正确区分不同来源的响应。</p>
+                <span class="badge badge-blue">性能相关</span>
+            </div>
+        </div>
+    </div>
+
+    <div class="card">
+        <div class="card-header">
+            <div class="card-icon green">📚</div>
+            <h2>参考资料</h2>
+        </div>
+        <table class="data-table">
+            <thead>
+                <tr><th>来源</th><th>链接</th></tr>
+            </thead>
+            <tbody>
+                <tr><td>MDN - CORS Errors</td><td><a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CORS/Errors/CORSMultipleAllowOriginNotAllowed" target="_blank" style="color:#818cf8">查看</a></td></tr>
+                <tr><td>PortSwigger - CORS</td><td><a href="https://portswigger.net/web-security/cors/access-control-allow-origin" target="_blank" style="color:#818cf8">查看</a></td></tr>
+                <tr><td>WHATWG Fetch Standard</td><td><a href="https://fetch.spec.whatwg.org/" target="_blank" style="color:#818cf8">查看</a></td></tr>
+                <tr><td>MDN - HTTP CORS</td><td><a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS" target="_blank" style="color:#818cf8">查看</a></td></tr>
+            </tbody>
+        </table>
+    </div>
+</div>
+
+<footer>
+    <p>基于 <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CORS/Errors/CORSMultipleAllowOriginNotAllowed" target="_blank">MDN</a> 和 <a href="https://portswigger.net/web-security/cors/access-control-allow-origin" target="_blank">PortSwigger</a> 资料整理 · <a href="https://github.com/zenHeart/learn-network" target="_blank">zenHeart/learn-network</a></p>
+</footer>
+
+</div>
+
+<script>
+function switchTab(tabId) {
+    document.querySelectorAll('.tab-btn').forEach(btn => btn.classList.remove('active'));
+    document.querySelectorAll('.tab-content').forEach(tab => tab.classList.remove('active'));
+    document.getElementById('tab-' + tabId).classList.add('active');
+    document.querySelectorAll('.tab-btn').forEach(btn => {
+        if (btn.getAttribute('onclick').includes(tabId)) btn.classList.add('active');
+    });
+}
+
+let selectedOrigin = null;
+function selectOrigin(el, origin) {
+    document.querySelectorAll('.origin-chip').forEach(c => c.classList.remove('selected'));
+    el.classList.add('selected');
+    selectedOrigin = origin;
+}
+
+function runSimulation() {
+    if (!selectedOrigin) {
+        alert('请先选择一个请求来源');
+        return;
+    }
+    const allowedOrigins = ['https://a.com', 'https://b.com', 'https://c.com'];
+    const result = document.getElementById('test-result');
+    const isAllowed = allowedOrigins.includes(selectedOrigin);
+
+    result.className = 'test-result show ' + (isAllowed ? 'success' : 'error');
+
+    if (isAllowed) {
+        result.innerHTML = '<strong>✅ 服务器允许该来源</strong><pre>' +
+            'HTTP/1.1 200 OK\n' +
+            'Access-Control-Allow-Origin: ' + selectedOrigin + '\n' +
+            'Access-Control-Allow-Credentials: true\n' +
+            'Content-Type: application/json\n\n' +
+            '{"data": "敏感数据 - 浏览器允许 JS 访问"}' +
+            '</pre>';
+    } else if (selectedOrigin === 'null') {
+        result.innerHTML = '<strong>⚠️ 警告：Origin 为 null</strong><pre>' +
+            'HTTP/1.1 200 OK\n' +
+            '(无 Access-Control-Allow-Origin 头部)\n\n' +
+            '浏览器拒绝 JS 访问响应（可能的安全风险）' +
+            '</pre>';
+    } else {
+        result.innerHTML = '<strong>❌ 服务器未允许该来源</strong><pre>' +
+            'HTTP/1.1 200 OK\n' +
+            '(无 Access-Control-Allow-Origin 头部)\n\n' +
+            '浏览器拒绝 JS 访问响应\n' +
+            'Error: ' + selectedOrigin + ' has been blocked by CORS policy' +
+            '</pre>';
+    }
+}
+
+function copyCode(btn) {
+    const code = btn.closest('.code-block').querySelector('.code-content').innerText;
+    navigator.clipboard.writeText(code).then(() => {
+        btn.textContent = '已复制!';
+        btn.classList.add('copied');
+        setTimeout(() => {
+            btn.textContent = '复制';
+            btn.classList.remove('copied');
+        }, 2000);
+    });
+}
+</script>
+</body>
+</html>

--- a/examples/ssl/certificate-demo.html
+++ b/examples/ssl/certificate-demo.html
@@ -1,0 +1,550 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>SSL/TLS 证书问题交互演示</title>
+  <style>
+    :root {
+      --bg: #0a0a0f;
+      --surface: #13131f;
+      --border: #1e1e2e;
+      --accent: #00d4aa;
+      --accent2: #7c3aed;
+      --text: #e4e4e7;
+      --text-muted: #71717a;
+      --green: #22c55e;
+      --red: #ef4444;
+      --yellow: #f59e0b;
+      --radius: 12px;
+    }
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      background: var(--bg);
+      color: var(--text);
+      font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace;
+      min-height: 100vh;
+      padding: 2rem;
+      line-height: 1.6;
+    }
+    h1 {
+      font-size: 1.8rem;
+      font-weight: 700;
+      background: linear-gradient(135deg, var(--accent), var(--accent2));
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      margin-bottom: 0.5rem;
+    }
+    .subtitle { color: var(--text-muted); font-size: 0.875rem; margin-bottom: 2rem; }
+    .tabs {
+      display: flex;
+      gap: 0.25rem;
+      margin-bottom: 1.5rem;
+      flex-wrap: wrap;
+      background: var(--surface);
+      padding: 0.25rem;
+      border-radius: var(--radius);
+      border: 1px solid var(--border);
+    }
+    .tab {
+      padding: 0.5rem 1rem;
+      border: none;
+      background: transparent;
+      color: var(--text-muted);
+      cursor: pointer;
+      border-radius: 8px;
+      font-family: inherit;
+      font-size: 0.8rem;
+      transition: all 0.2s;
+    }
+    .tab:hover { color: var(--text); background: var(--border); }
+    .tab.active { background: var(--accent); color: #000; font-weight: 600; }
+    .tab-content { display: none; }
+    .tab-content.active { display: block; }
+    .card {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      padding: 1.5rem;
+      margin-bottom: 1rem;
+    }
+    .card-title {
+      font-size: 0.75rem;
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      color: var(--accent);
+      margin-bottom: 1rem;
+    }
+    .chain-container {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 0;
+      margin: 1.5rem 0;
+    }
+    .chain-node {
+      display: flex;
+      align-items: center;
+      gap: 1rem;
+      padding: 0.75rem 1.25rem;
+      border-radius: var(--radius);
+      border: 2px solid;
+      width: 100%;
+      max-width: 520px;
+      position: relative;
+      transition: all 0.3s;
+    }
+    .chain-node.root { border-color: var(--accent2); background: rgba(124,58,237,0.1); }
+    .chain-node.intermediate { border-color: var(--yellow); background: rgba(245,158,11,0.1); }
+    .chain-node.server { border-color: var(--accent); background: rgba(0,212,170,0.1); }
+    .chain-node.error { border-color: var(--red); background: rgba(239,68,68,0.1); }
+    .chain-node.valid { border-color: var(--green); background: rgba(34,197,94,0.1); }
+    .chain-node-label {
+      font-size: 0.7rem;
+      color: var(--text-muted);
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      position: absolute;
+      top: -0.5rem;
+      left: 1rem;
+      background: var(--bg);
+      padding: 0 0.5rem;
+    }
+    .chain-node-icon { font-size: 1.5rem; flex-shrink: 0; }
+    .chain-node-info { flex: 1; }
+    .chain-node-name { font-weight: 600; font-size: 0.9rem; }
+    .chain-node-detail { font-size: 0.75rem; color: var(--text-muted); margin-top: 0.15rem; }
+    .chain-arrow { font-size: 1.2rem; color: var(--text-muted); padding: 0.25rem 0; }
+    .status-badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.35rem;
+      padding: 0.2rem 0.6rem;
+      border-radius: 20px;
+      font-size: 0.7rem;
+      font-weight: 600;
+      flex-shrink: 0;
+    }
+    .status-badge.ok { background: rgba(34,197,94,0.2); color: var(--green); }
+    .status-badge.error { background: rgba(239,68,68,0.2); color: var(--red); }
+    .status-badge.warn { background: rgba(245,158,11,0.2); color: var(--yellow); }
+    .selector-group { display: flex; gap: 0.5rem; flex-wrap: wrap; margin-bottom: 1rem; }
+    .selector-btn {
+      padding: 0.4rem 0.85rem;
+      border: 1px solid var(--border);
+      background: transparent;
+      color: var(--text);
+      border-radius: 6px;
+      cursor: pointer;
+      font-family: inherit;
+      font-size: 0.8rem;
+      transition: all 0.2s;
+    }
+    .selector-btn:hover { border-color: var(--accent); }
+    .selector-btn.active { background: var(--accent); color: #000; border-color: var(--accent); }
+    table { width: 100%; border-collapse: collapse; font-size: 0.8rem; margin-top: 1rem; }
+    th {
+      text-align: left;
+      color: var(--accent);
+      padding: 0.5rem 0.75rem;
+      border-bottom: 1px solid var(--border);
+      font-size: 0.7rem;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+    }
+    td { padding: 0.5rem 0.75rem; border-bottom: 1px solid var(--border); vertical-align: top; }
+    tr:last-child td { border-bottom: none; }
+    td code { color: var(--yellow); }
+    .cmd-block {
+      background: #000;
+      border-radius: 8px;
+      padding: 1rem;
+      margin: 0.75rem 0;
+      overflow-x: auto;
+    }
+    .cmd-title { color: var(--text); font-size: 0.85rem; margin-bottom: 0.5rem; font-weight: 600; }
+    .cmd-prompt { color: var(--accent); }
+    .cmd-cmd { color: var(--text); font-size: 0.82rem; margin-bottom: 0.25rem; word-break: break-all; }
+    .cmd-out { color: var(--green); font-size: 0.78rem; white-space: pre-wrap; word-break: break-all; }
+    .browser-sim {
+      background: rgba(239,68,68,0.06);
+      border: 1px solid rgba(239,68,68,0.2);
+      border-radius: var(--radius);
+      overflow: hidden;
+    }
+    .browser-sim-header {
+      background: #1a1a2e;
+      padding: 0.5rem 0.75rem;
+      display: flex;
+      gap: 0.5rem;
+      align-items: center;
+    }
+    .browser-sim-dot { width: 10px; height: 10px; border-radius: 50%; flex-shrink: 0; }
+    .browser-sim-body { padding: 2rem; text-align: center; }
+    .browser-sim-body .icon { font-size: 3rem; margin-bottom: 1rem; }
+    .browser-sim-body h3 { color: var(--text); font-size: 1rem; margin-bottom: 0.5rem; }
+    .browser-sim-body p { color: var(--text-muted); font-size: 0.8rem; margin-bottom: 0.75rem; }
+    .browser-sim-error {
+      background: rgba(239,68,68,0.12);
+      border: 1px solid rgba(239,68,68,0.3);
+      border-radius: 8px;
+      padding: 0.5rem 1rem;
+      display: inline-block;
+      color: var(--red);
+      font-size: 0.8rem;
+      font-weight: 600;
+    }
+    .tree { font-size: 0.85rem; color: var(--text-muted); line-height: 2.2; }
+    .tree strong { color: var(--text); }
+    .tree a { color: var(--accent); }
+    .footer {
+      margin-top: 2rem;
+      padding-top: 1rem;
+      border-top: 1px solid var(--border);
+      font-size: 0.75rem;
+      color: var(--text-muted);
+      text-align: center;
+    }
+    @keyframes pulse-error {
+      0%, 100% { box-shadow: 0 0 0 0 rgba(239,68,68,0.4); }
+      50% { box-shadow: 0 0 0 8px rgba(239,68,68,0); }
+    }
+    .pulse-error { animation: pulse-error 1.5s infinite; }
+  </style>
+</head>
+<body>
+
+<h1>SSL/TLS 证书问题交互演示</h1>
+<p class="subtitle">learn-network / examples / ssl / certificate-demo.html</p>
+
+<div class="tabs">
+  <button class="tab active" data-tab="chain">证书链结构</button>
+  <button class="tab" data-tab="browser">浏览器提示</button>
+  <button class="tab" data-tab="openssl">OpenSSL 排查</button>
+  <button class="tab" data-tab="compat">兼容性</button>
+  <button class="tab" data-tab="troubleshoot">排查流程</button>
+</div>
+
+<!-- Tab: Chain -->
+<div id="tab-chain" class="tab-content active">
+  <div class="card">
+    <div class="card-title">选择证书问题类型</div>
+    <div class="selector-group" id="chain-selector">
+      <button class="selector-btn active" data-type="valid">完整有效链</button>
+      <button class="selector-btn" data-type="expired">证书过期</button>
+      <button class="selector-btn" data-type="incomplete">链不完整</button>
+      <button class="selector-btn" data-type="mismatch">域名不匹配</button>
+      <button class="selector-btn" data-type="selfsigned">自签名证书</button>
+      <button class="selector-btn" data-type="root-expired">根证书过期</button>
+    </div>
+  </div>
+  <div id="chain-display"></div>
+  <div class="card">
+    <div class="card-title">说明</div>
+    <p style="color: var(--text-muted); font-size: 0.85rem;" id="explanation-text">选择不同的场景，查看对应的证书链状态和浏览器行为。</p>
+  </div>
+</div>
+
+<!-- Tab: Browser -->
+<div id="tab-browser" class="tab-content">
+  <div class="card">
+    <div class="card-title">浏览器错误提示对照表</div>
+    <table>
+      <thead>
+        <tr><th>问题类型</th><th>Chrome / Edge</th><th>Firefox</th><th>Safari</th></tr>
+      </thead>
+      <tbody>
+        <tr><td>证书本身过期</td><td><code>ERR_CERT_EXPIRED</code></td><td><code>MOZILLA_PKIX_ERROR_CERT_EXPIRED</code></td><td>"证书已过期"</td></tr>
+        <tr><td>证书链不完整</td><td><code>ERR_CERT_AUTHORITY_INVALID</code></td><td><code>SEC_ERROR_UNKNOWN_ISSUER</code></td><td>"无法验证网站身份"</td></tr>
+        <tr><td>域名不匹配</td><td><code>ERR_CERT_COMMON_NAME_INVALID</code></td><td><code>SSL_ERROR_BAD_CERT_DOMAIN</code></td><td>"Safari 无法验证网站身份"</td></tr>
+        <tr><td>自签名证书</td><td><code>ERR_CERT_AUTHORITY_INVALID</code></td><td><code>SEC_ERROR_UNTRUSTED_ISSUER</code></td><td>"此证书不受信任"</td></tr>
+        <tr><td>根证书过期</td><td><code>CERT_HAS_EXPIRED</code></td><td><code>MOZILLA_PKIX_ERROR_PATH_LEN_EXCEEDED</code></td><td>"证书链无效"</td></tr>
+      </tbody>
+    </table>
+  </div>
+  <div class="card">
+    <div class="card-title">模拟浏览器错误界面（点击上方「证书链结构」中的场景）</div>
+    <div id="browser-sim-panel">
+      <p style="color: var(--text-muted); font-size: 0.85rem;">在上方选择有问题的场景，查看对应的模拟错误界面。</p>
+    </div>
+  </div>
+</div>
+
+<!-- Tab: OpenSSL -->
+<div id="tab-openssl" class="tab-content">
+  <div class="selector-group" id="cmd-selector">
+    <button class="selector-btn active" data-cmd="info">查看证书信息</button>
+    <button class="selector-btn" data-cmd="chain">检查证书链</button>
+    <button class="selector-btn" data-cmd="verify">验证证书</button>
+    <button class="selector-btn" data-cmd="match">匹配私钥</button>
+  </div>
+  <div id="cmd-display"></div>
+</div>
+
+<!-- Tab: Compatibility -->
+<div id="tab-compat" class="tab-content">
+  <div class="card">
+    <div class="card-title">Let's Encrypt 根 CA 兼容性</div>
+    <table>
+      <thead><tr><th>设备 / 平台</th><th>ISRG Root X1</th><th>ISRG Root X2</th><th>备注</th></tr></thead>
+      <tbody>
+        <tr><td>Android 7.1+</td><td><span class="status-badge ok">支持</span></td><td><span class="status-badge error">不支持</span></td><td>7.0 以下需 DST Root CA X3</td></tr>
+        <tr><td>Firefox (全版本)</td><td><span class="status-badge ok">支持</span></td><td><span class="status-badge ok">支持</span></td><td>内置自己的根 CA 列表</td></tr>
+        <tr><td>Chrome / Win / Mac</td><td><span class="status-badge ok">支持</span></td><td><span class="status-badge ok">支持</span></td><td>依赖系统根 CA</td></tr>
+        <tr><td>Java 11+</td><td><span class="status-badge ok">支持</span></td><td><span class="status-badge warn">部分</span></td><td>旧 JDK 版本可能有问题</td></tr>
+        <tr><td>OpenSSL 1.1.1+</td><td><span class="status-badge ok">支持</span></td><td><span class="status-badge ok">支持</span></td><td>—</td></tr>
+      </tbody>
+    </table>
+  </div>
+  <div class="card">
+    <div class="card-title">签名算法与密钥长度</div>
+    <table>
+      <thead><tr><th>类型</th><th>算法 / 长度</th><th>兼容性</th><th>说明</th></tr></thead>
+      <tbody>
+        <tr><td>签名算法</td><td>SHA-1 with RSA</td><td><span class="status-badge error">已废弃</span></td><td>2020 年起所有浏览器拒绝</td></tr>
+        <tr><td>签名算法</td><td>SHA-256 with RSA</td><td><span class="status-badge ok">通用</span></td><td>最低要求</td></tr>
+        <tr><td>椭圆曲线</td><td>ECDSA P-256</td><td><span class="status-badge ok">推荐</span></td><td>更小更快，渐成主流</td></tr>
+        <tr><td>椭圆曲线</td><td>ECDSA P-384</td><td><span class="status-badge ok">高安全</span></td><td>金融等高安全场景</td></tr>
+        <tr><td>RSA 密钥</td><td>2048-bit</td><td><span class="status-badge ok">最低要求</span></td><td>—</td></tr>
+        <tr><td>RSA 密钥</td><td>4096-bit</td><td><span class="status-badge warn">注意</span></td><td>老旧设备可能不支持</td></tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+
+<!-- Tab: Troubleshooting -->
+<div id="tab-troubleshoot" class="tab-content">
+  <div class="card">
+    <div class="card-title">排查决策树</div>
+    <div class="tree">
+      <div>1. 浏览器报证书错误？</div>
+      <div>&nbsp;&nbsp;|- 是 → DevTools → <strong>Security 面板</strong> 查看证书详情和路径</div>
+      <div>&nbsp;&nbsp;|- "证书已过期" → <strong style="color:var(--yellow)">检查有效期</strong> → 续期证书</div>
+      <div>&nbsp;&nbsp;|- "无法验证身份" → <strong style="color:var(--yellow)">检查证书链</strong> → 补全中间证书</div>
+      <div>&nbsp;&nbsp;|- "域名不匹配" → <strong style="color:var(--yellow)">检查 SAN/CN</strong> → 重新申请</div>
+      <div>&nbsp;&nbsp;|- "不受信任" → <strong style="color:var(--yellow)">检查根 CA</strong> → 自签名? 导入根证书</div>
+      <div>&nbsp;&nbsp;|- 控制台混合内容警告 → <strong style="color:var(--yellow)">检查资源 URL</strong> → 改用 HTTPS</div>
+      <div>&nbsp;&nbsp;|- 仍无法确定 → <strong>openssl s_client -connect site:443 -showcerts</strong></div>
+      <div>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;→ 使用 <a href="https://www.ssllabs.com/ssltest/" target="_blank">SSL Labs</a> 做全面检测</div>
+    </div>
+  </div>
+  <div class="card">
+    <div class="card-title">快速修复命令</div>
+    <div class="cmd-block">
+      <div class="cmd-title">检查证书有效期</div>
+      <div class="cmd-cmd"><span class="cmd-prompt">$</span> openssl x509 -in server.crt -noout -dates</div>
+      <div class="cmd-out">notBefore=Jun  1 00:00:00 2024 GMT
+notAfter=Jun  1 00:00:00 2025 GMT</div>
+    </div>
+    <div class="cmd-block">
+      <div class="cmd-title">检查证书支持的域名</div>
+      <div class="cmd-cmd"><span class="cmd-prompt">$</span> openssl x509 -in server.crt -noout -ext subjectAltName</div>
+      <div class="cmd-out">X509v3 Subject Alternative Name:
+    DNS:example.com, DNS:www.example.com</div>
+    </div>
+    <div class="cmd-block">
+      <div class="cmd-title">连接服务器检查证书链</div>
+      <div class="cmd-cmd"><span class="cmd-prompt">$</span> openssl s_client -connect example.com:443 -showcerts</div>
+      <div class="cmd-out">Verify return code: 0 (ok)</div>
+    </div>
+    <div class="cmd-block">
+      <div class="cmd-title">验证完整证书链</div>
+      <div class="cmd-cmd"><span class="cmd-prompt">$</span> openssl verify -CAfile root.crt -untrusted int.crt server.crt</div>
+      <div class="cmd-out">server.crt: OK</div>
+    </div>
+  </div>
+</div>
+
+<div class="footer">learn-network / examples / ssl / certificate-demo.html</div>
+
+<script>
+  // Tab switching
+  document.querySelectorAll('.tab').forEach(tab => {
+    tab.addEventListener('click', () => {
+      document.querySelectorAll('.tab').forEach(t => t.classList.remove('active'));
+      document.querySelectorAll('.tab-content').forEach(c => c.classList.remove('active'));
+      tab.classList.add('active');
+      document.getElementById('tab-' + tab.dataset.tab).classList.add('active');
+    });
+  });
+
+  // Certificate chain data
+  const chainData = {
+    valid: {
+      nodes: [
+        { type: 'root', icon: '🏛️', name: 'DigiCert Global Root G2', detail: '有效期: 2023-01-01 ~ 2043-01-01 · 受信任根CA', status: 'valid' },
+        { type: 'intermediate', icon: '📜', name: 'DigiCert SHA2 Extended Validation Server CA', detail: '有效期: 2023-08-01 ~ 2031-08-01 · 中间CA', status: 'valid' },
+        { type: 'server', icon: '🖥️', name: 'example.com', detail: '有效期: 2024-06-01 ~ 2025-06-01 · CN=example.com, SAN=example.com,www.example.com', status: 'valid' },
+      ],
+      explanation: '完整证书链：浏览器从服务器证书逐级验证到受信任根CA，连接安全。',
+      browserMsg: null
+    },
+    expired: {
+      nodes: [
+        { type: 'root', icon: '🏛️', name: 'DigiCert Global Root G2', detail: '有效期: 2023-01-01 ~ 2043-01-01 · 受信任根CA', status: 'valid' },
+        { type: 'intermediate', icon: '📜', name: 'DigiCert SHA2 Extended Validation Server CA', detail: '有效期: 2023-08-01 ~ 2031-08-01 · 中间CA', status: 'valid' },
+        { type: 'server', icon: '🖥️', name: 'example.com', detail: '⚠ 有效期: 2024-06-01 ~ 2025-01-15 · 已过期！', status: 'error' },
+      ],
+      explanation: '终端证书已过期。浏览器显示 ERR_CERT_EXPIRED，需要及时续期证书。',
+      browserMsg: { err: 'ERR_CERT_EXPIRED', detail: '此连接不是私密连接 — 攻击者可能会试图从 example.com 窃取信息' }
+    },
+    incomplete: {
+      nodes: [
+        { type: 'root', icon: '🏛️', name: 'DigiCert Global Root G2', detail: '有效期: 2023-01-01 ~ 2043-01-01 · 受信任根CA', status: 'valid' },
+        { type: 'intermediate', icon: '❓', name: '中间证书（未提供）', detail: '服务器未发送中间证书，浏览器无法验证到根CA', status: 'error' },
+        { type: 'server', icon: '🖥️', name: 'example.com', detail: '有效期: 2024-06-01 ~ 2025-06-01 · 但无法验证信任链', status: 'error' },
+      ],
+      explanation: '证书链不完整：服务器未发送中间证书，常见原因是Nginx配置了server.crt而非fullchain.pem。',
+      browserMsg: { err: 'ERR_CERT_AUTHORITY_INVALID', detail: '无法验证网站身份 — 证书颁发者无效' }
+    },
+    mismatch: {
+      nodes: [
+        { type: 'root', icon: '🏛️', name: 'DigiCert Global Root G2', detail: '有效期: 2023-01-01 ~ 2043-01-01 · 受信任根CA', status: 'valid' },
+        { type: 'intermediate', icon: '📜', name: 'DigiCert SHA2 Extended Validation Server CA', detail: '有效期: 2023-08-01 ~ 2031-08-01 · 中间CA', status: 'valid' },
+        { type: 'server', icon: '🖥️', name: 'example.com', detail: 'CN=example.com · 但访问的是 api.example.com（不匹配）', status: 'error' },
+      ],
+      explanation: '域名不匹配：证书的CN/SAN不包含当前访问的域名api.example.com。需要在申请证书时添加所有域名。',
+      browserMsg: { err: 'ERR_CERT_COMMON_NAME_INVALID', detail: '服务器证书的域名与访问的域名不匹配' }
+    },
+    selfsigned: {
+      nodes: [
+        { type: 'server', icon: '🔒', name: 'Self-Signed Certificate', detail: '自己签自己 · 根CA不在浏览器信任列表中', status: 'error' },
+      ],
+      explanation: '自签名证书：证书由自己签发，没有经过受信任CA的认证。开发/测试环境常见。',
+      browserMsg: { err: 'ERR_CERT_AUTHORITY_INVALID', detail: '证书颁发者无效/不受信任 — 自签名或私有CA签发' }
+    },
+    'root-expired': {
+      nodes: [
+        { type: 'root', icon: '🏛️', name: 'Thawte Primary Root CA', detail: '有效期: 2006-01-01 ~ 2021-01-01 · 已过期！', status: 'error' },
+        { type: 'intermediate', icon: '📜', name: 'Thawte SSL CA', detail: '有效期: 2020-01-01 ~ 2030-01-01 · 但根已过期', status: 'error' },
+        { type: 'server', icon: '🖥️', name: 'example.com', detail: '有效期: 2024-06-01 ~ 2025-06-01 · 但根CA已过期', status: 'error' },
+      ],
+      explanation: '根证书过期：即使服务器和中间证书都在有效期内，只要根CA过期，整条链就失效。老旧设备常见此问题。',
+      browserMsg: { err: 'CERT_HAS_EXPIRED', detail: '证书链中的根CA证书已过期' }
+    }
+  };
+
+  function renderChain(type) {
+    const container = document.getElementById('chain-display');
+    const data = chainData[type];
+    let html = '<div class="chain-container">';
+    data.nodes.forEach((node, i) => {
+      if (i > 0) html += '<div class="chain-arrow">⬇ 签名验证</div>';
+      const label = node.type === 'root' ? '根CA' : node.type === 'intermediate' ? '中间CA' : '服务器';
+      html += `
+        <div class="chain-node ${node.type} ${node.status === 'error' ? 'pulse-error' : ''}">
+          <span class="chain-node-label">${label}</span>
+          <span class="chain-node-icon">${node.icon}</span>
+          <div class="chain-node-info">
+            <div class="chain-node-name">${node.name}</div>
+            <div class="chain-node-detail">${node.detail}</div>
+          </div>
+          <span class="status-badge ${node.status === 'valid' ? 'ok' : 'error'}">${node.status === 'valid' ? '✓ 有效' : '✗ 无效'}</span>
+        </div>`;
+    });
+    html += '</div>';
+    container.innerHTML = html;
+    document.getElementById('explanation-text').textContent = data.explanation;
+    renderBrowserSim(data.browserMsg);
+  }
+
+  function renderBrowserSim(msg) {
+    const container = document.getElementById('browser-sim-panel');
+    if (!msg) {
+      container.innerHTML = `<div style="text-align:center;padding:2rem;color:var(--green);">
+        <div style="font-size:3rem;margin-bottom:1rem;">🔒</div>
+        <div style="font-size:1rem;font-weight:600;">连接安全</div>
+        <div style="font-size:0.8rem;color:var(--text-muted);margin-top:0.5rem;">证书链完整且在有效期内</div>
+      </div>`;
+      return;
+    }
+    container.innerHTML = `<div class="browser-sim">
+      <div class="browser-sim-header">
+        <span class="browser-sim-dot" style="background:#ef4444;"></span>
+        <span class="browser-sim-dot" style="background:#f59e0b;"></span>
+        <span class="browser-sim-dot" style="background:#22c55e;"></span>
+        <span style="color:var(--text-muted);font-size:0.7rem;margin-left:0.5rem;">chrome://net-internals/#ssl</span>
+      </div>
+      <div class="browser-sim-body">
+        <div class="icon">🔒</div>
+        <h3>您的连接不是私密连接</h3>
+        <p>攻击者可能会试图从 <strong>example.com</strong> 窃取您的信息。</p>
+        <div class="browser-sim-error">${msg.err}</div>
+        <p style="margin-top:0.75rem;font-size:0.75rem;color:var(--text-muted);">${msg.detail}</p>
+      </div>
+    </div>`;
+  }
+
+  // Init
+  renderChain('valid');
+  document.querySelectorAll('#chain-selector .selector-btn').forEach(btn => {
+    btn.addEventListener('click', () => {
+      document.querySelectorAll('#chain-selector .selector-btn').forEach(b => b.classList.remove('active'));
+      btn.classList.add('active');
+      renderChain(btn.dataset.type);
+    });
+  });
+
+  // OpenSSL commands data
+  const cmdData = {
+    info: {
+      title: '查看证书信息',
+      items: [
+        { label: '查看证书有效期', cmd: 'openssl x509 -in server.crt -noout -dates', out: 'notBefore=Jun  1 00:00:00 2024 GMT\nnotAfter=Jun  1 00:00:00 2025 GMT' },
+        { label: '查看证书支持的域名（SAN）', cmd: 'openssl x509 -in server.crt -noout -ext subjectAltName', out: 'X509v3 Subject Alternative Name:\n    DNS:example.com, DNS:www.example.com' },
+        { label: '查看证书指纹（用于对比）', cmd: 'openssl x509 -in server.crt -noout -fingerprint -sha256', out: 'SHA256 Fingerprint=43:5A:B2:AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD:EE:FF:2D' },
+        { label: '查看证书完整信息', cmd: 'openssl x509 -in server.crt -noout -text | head -20', out: 'Certificate:\n    Data:\n        Version: 3 (0x2)\n        Serial Number:\n            04:3f:c2:ae:12:3d:4e:5f:6a:7b:8c:9d:0e:1f:2a:3b\n        Signature Algorithm: sha256WithRSAEncryption\n        Issuer: C=US, O=DigiCert Inc, CN=DigiCert SHA2 Extended Validation Server CA' },
+      ]
+    },
+    chain: {
+      title: '检查证书链',
+      items: [
+        { label: '连接服务器查看完整证书链', cmd: 'openssl s_client -connect example.com:443 -showcerts', out: 'Certificate chain\n 0 s:example.com\n   i:/C=US/O=DigiCert Inc/CN=DigiCert SHA2 Extended Validation Server CA\n 1 s:/C=US/O=DigiCert Inc/CN=DigiCert SHA2 Extended Validation Server CA\n   i:/C=US/O=DigiCert Inc/CN=DigiCert Global Root G2' },
+        { label: '查看验证结果代码', cmd: 'openssl s_client -connect example.com:443 </dev/null 2>&1 | grep "Verify return code"', out: 'Verify return code: 0 (ok)' },
+        { label: '检查证书链完整性（部分链）', cmd: 'openssl s_client -connect example.com:443 -partial_chain -showcerts', out: 'Verify return code: 20 (unable to get local issuer certificate)' },
+      ]
+    },
+    verify: {
+      title: '验证证书',
+      items: [
+        { label: '使用 CA 验证服务器证书', cmd: 'openssl verify -CAfile ca.crt server.crt', out: 'server.crt: OK' },
+        { label: '验证完整证书链', cmd: 'openssl verify -CAfile root.crt -untrusted int.crt server.crt', out: 'server.crt: OK' },
+        { label: '常见验证返回码说明', cmd: '# 0  = 验证成功\n# 19 = 证书链不完整（根CA自签名）\n# 20 = 找不到中间证书\n# 21 = 无法验证到受信任根CA', out: null },
+      ]
+    },
+    match: {
+      title: '匹配私钥',
+      items: [
+        { label: '提取证书公钥指纹', cmd: 'openssl x509 -in cert.pem -pubkey -noout | openssl pkey -pubout -outform der | openssl md5', out: '(stdin)= 5d291e2ed3a6bafe3a0268e301a1b6cf' },
+        { label: '提取私钥公钥指纹', cmd: 'openssl pkey -in privkey.pem -pubout -outform der | openssl md5', out: '(stdin)= 5d291e2ed3a6bafe3a0268e301a1b6cf' },
+        { label: '对比两个指纹', cmd: '# 指纹相同则私钥与证书匹配', out: '如果两个指纹相同，说明私钥和证书是一对。' },
+      ]
+    }
+  };
+
+  function renderCmd(type) {
+    const container = document.getElementById('cmd-display');
+    const data = cmdData[type];
+    let html = '<div class="card"><div class="card-title">' + data.title + '</div>';
+    data.items.forEach(item => {
+      html += '<div class="cmd-block"><div class="cmd-title">' + item.label + '</div>';
+      html += '<div class="cmd-cmd"><span class="cmd-prompt">$</span> ' + item.cmd.replace(/</g, '&lt;') + '</div>';
+      if (item.out) html += '<div class="cmd-out">' + item.out + '</div>';
+      html += '</div>';
+    });
+    html += '</div>';
+    container.innerHTML = html;
+  }
+
+  // Init OpenSSL tab
+  renderCmd('info');
+  document.querySelectorAll('#cmd-selector .selector-btn').forEach(btn => {
+    btn.addEventListener('click', () => {
+      document.querySelectorAll('#cmd-selector .selector-btn').forEach(b => b.classList.remove('active'));
+      btn.classList.add('active');
+      renderCmd(btn.dataset.cmd);
+    });
+  });
+</script>
+</body>
+</html>

--- a/examples/websocket/connection-demo/websocket-connection-demo.html
+++ b/examples/websocket/connection-demo/websocket-connection-demo.html
@@ -1,0 +1,498 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="UTF-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+<title>WebSocket 连接流程交互演示</title>
+<style>
+:root{--bg:#0f0f1a;--surface:#1a1a2e;--surface2:#16213e;--accent:#00d9ff;--accent2:#7b2ff7;--success:#00c853;--error:#ff1744;--warn:#ffab00;--text:#e0e0e0;--muted:#888;}
+*{box-sizing:border-box;margin:0;padding:0;}
+body{font-family:"SF Mono","Fira Code","Consolas",monospace;background:var(--bg);color:var(--text);min-height:100vh;padding:24px;line-height:1.6;max-width:900px;margin:0 auto;}
+h1{font-size:1.4rem;color:var(--accent);margin-bottom:8px;}
+h2{font-size:1rem;color:var(--accent2);margin:24px 0 10px;border-bottom:1px solid var(--surface2);padding-bottom:4px;}
+p{font-size:0.82rem;color:var(--muted);margin-bottom:8px;}
+.status-bar{display:flex;gap:10px;margin:12px 0;font-size:0.72rem;flex-wrap:wrap;}
+.status-item{padding:4px 10px;border-radius:4px;background:var(--surface);border:1px solid var(--surface2);transition:all 0.3s;}
+.status-item.active{border-color:var(--success);color:var(--success);box-shadow:0 0 8px rgba(0,200,83,0.3);}
+.flow-diagram{background:var(--surface);border:1px solid var(--surface2);border-radius:8px;padding:16px;margin:12px 0;}
+.flow-step{display:flex;align-items:center;gap:12px;padding:8px 0;opacity:0.35;transition:all 0.5s;}
+.flow-step.done{opacity:1;}
+.flow-step.active{opacity:1;}
+.step-num{width:24px;height:24px;border-radius:50%;background:var(--surface2);border:1px solid var(--muted);display:flex;align-items:center;justify-content:center;font-size:0.68rem;flex-shrink:0;transition:all 0.3s;}
+.flow-step.done .step-num{background:var(--success);border-color:var(--success);color:#000;}
+.flow-step.active .step-num{background:var(--accent);border-color:var(--accent);color:#000;animation:pulse 1s infinite;}
+@keyframes pulse{0%,100%{box-shadow:0 0 0 0 rgba(0,217,255,0.4);}50%{box-shadow:0 0 0 8px rgba(0,217,255,0);}}
+.step-label{flex:1;font-size:0.78rem;}
+.step-detail{font-size:0.68rem;color:var(--muted);margin-top:2px;}
+.flow-arrow{color:var(--muted);font-size:0.68rem;padding-left:36px;height:14px;}
+.handshake-box{background:var(--surface);border:1px solid var(--surface2);border-radius:8px;padding:14px;margin:10px 0;font-size:0.72rem;}
+.handshake-line{padding:2px 0;}
+.h-line{color:var(--accent);}
+.h-key{color:var(--accent2);}
+.h-val{color:var(--success);}
+.h-code{color:var(--warn);}
+.frame-visual{background:var(--surface);border:1px solid var(--surface2);border-radius:8px;padding:14px;margin:10px 0;font-size:0.72rem;overflow-x:auto;}
+.frame-byte{display:inline-block;width:30px;height:28px;line-height:28px;text-align:center;border-radius:4px;margin:2px;font-size:0.62rem;}
+.frame-byte.fin{background:var(--accent);color:#000;}
+.frame-byte.rsv{background:var(--warn);color:#000;}
+.frame-byte.opcode{background:var(--accent2);color:#fff;}
+.frame-byte.mask{background:var(--success);color:#000;}
+.frame-byte.len{background:var(--error);color:#fff;}
+.frame-byte.mask-key{background:#e91e63;color:#fff;}
+.frame-byte.payload{background:var(--surface2);border:1px solid var(--muted);}
+.frame-legend{display:flex;flex-wrap:wrap;gap:12px;margin-top:12px;font-size:0.68rem;}
+.legend-item{display:flex;align-items:center;gap:6px;}
+.legend-dot{width:12px;height:12px;border-radius:3px;}
+.log-area{background:#000;border:1px solid var(--surface2);border-radius:8px;padding:12px;margin:12px 0;font-size:0.7rem;max-height:280px;overflow-y:auto;font-family:"SF Mono",monospace;}
+.log-entry{padding:3px 0;border-bottom:1px solid #111;}
+.log-time{color:var(--muted);}
+.log-info{color:var(--accent);}
+.log-success{color:var(--success);}
+.log-error{color:var(--error);}
+.log-warn{color:var(--warn);}
+.controls{display:flex;flex-wrap:wrap;gap:8px;margin:12px 0;}
+button{padding:8px 16px;border-radius:6px;border:1px solid var(--accent);background:transparent;color:var(--accent);font-family:inherit;font-size:0.72rem;cursor:pointer;transition:all 0.2s;}
+button:hover:not(:disabled){background:var(--accent);color:#000;}
+button:disabled{opacity:0.3;cursor:not-allowed;}
+button.primary{border-color:var(--accent2);color:var(--accent2);}
+button.primary:hover:not(:disabled){background:var(--accent2);color:#fff;}
+button.danger{border-color:var(--error);color:var(--error);}
+button.danger:hover:not(:disabled){background:var(--error);color:#fff;}
+.heartbeat-visual{display:flex;align-items:center;gap:10px;padding:14px;background:var(--surface);border-radius:8px;margin:12px 0;}
+.heartbeat-line{flex:1;height:2px;background:var(--surface2);position:relative;}
+.heartbeat-dot{width:10px;height:10px;border-radius:50%;background:var(--accent);position:absolute;top:-4px;left:0;transition:left 0.4s ease,background 0.2s;}
+.heartbeat-dot.ping{background:var(--warn);}
+.heartbeat-dot.pong{background:var(--success);}
+.hb-label{font-size:0.68rem;color:var(--muted);width:50px;text-align:center;}
+table{width:100%;border-collapse:collapse;font-size:0.72rem;margin:8px 0;}
+th,td{padding:6px 8px;border:1px solid var(--surface2);text-align:left;}
+th{background:var(--surface2);color:var(--accent2);}
+tr:hover{background:var(--surface2);}
+.code{color:var(--warn);font-weight:bold;}
+.modal-overlay{display:none;position:fixed;inset:0;background:rgba(0,0,0,0.7);z-index:100;align-items:center;justify-content:center;}
+.modal-overlay.show{display:flex;}
+.modal{background:var(--surface);border:1px solid var(--accent);border-radius:12px;padding:24px;max-width:580px;width:90%;max-height:80vh;overflow-y:auto;font-size:0.76rem;}
+.modal h3{color:var(--accent);margin-bottom:12px;}
+.modal pre{background:#000;padding:12px;border-radius:6px;overflow-x:auto;font-size:0.68rem;margin:8px 0;}
+</style>
+</head>
+<body>
+<h1>WebSocket 连接流程交互演示</h1>
+<p>本页面演示 WebSocket 完整生命周期：握手机制、数据帧格式、心跳保活和重连策略。使用本地服务器 <code>ws://localhost:8080</code>，请先运行 <code>node examples/websocket/handshake/server.js</code> 启动测试服务器。</p>
+
+<h2>1. 连接状态</h2>
+<div class="status-bar">
+  <div class="status-item" id="st0">CONNECTING(0)</div>
+  <div class="status-item" id="st1">OPEN(1)</div>
+  <div class="status-item" id="st2">CLOSING(2)</div>
+  <div class="status-item" id="st3">CLOSED(3)</div>
+</div>
+<div class="controls">
+  <button onclick="connectWS()" id="btn-connect">建立连接</button>
+  <button onclick="sendTestMsg()" id="btn-send" disabled>发送消息</button>
+  <button onclick="sendHeartbeat()" id="btn-hb" disabled>发送心跳</button>
+  <button onclick="closeWS()" id="btn-close" disabled class="danger">关闭连接</button>
+  <button onclick="simulateDisconnect()" id="btn-disconnect" class="primary">模拟断连</button>
+</div>
+
+<h2>2. 连接流程</h2>
+<div class="flow-diagram">
+  <div class="flow-step" id="step-tcp"><div class="step-num">1</div><div><div class="step-label">TCP 三次握手</div><div class="step-detail">SYN → SYN-ACK → ACK，建立可靠连接</div></div></div>
+  <div class="flow-arrow">↓</div>
+  <div class="flow-step" id="step-upgrade"><div class="step-num">2</div><div><div class="step-label">HTTP Upgrade 请求</div><div class="step-detail">Connection: Upgrade, Upgrade: websocket, Sec-WebSocket-Key</div></div></div>
+  <div class="flow-arrow">↓</div>
+  <div class="flow-step" id="step-handshake"><div class="step-num">3</div><div><div class="step-label">Sec-WebSocket-Key 握手验证</div><div class="step-detail">Key + GUID → SHA1 → Base64 = Sec-WebSocket-Accept</div></div></div>
+  <div class="flow-arrow">↓</div>
+  <div class="flow-step" id="step-101"><div class="step-num">4</div><div><div class="step-label">101 Switching Protocols</div><div class="step-detail">协议切换完成，TCP 连接升级为 WebSocket</div></div></div>
+  <div class="flow-arrow">↓</div>
+  <div class="flow-step" id="step-open"><div class="step-num">5</div><div><div class="step-label">onopen 事件触发</div><div class="step-detail">连接已打开，可进行全双工双向通信</div></div></div>
+</div>
+
+<h2>3. 握手请求 / 响应</h2>
+<div class="handshake-box">
+  <div class="handshake-line h-line">GET / HTTP/1.1</div>
+  <div class="handshake-line h-key">Host: localhost:8080</div>
+  <div class="handshake-line h-key">Connection: <span class="h-val">Upgrade</span></div>
+  <div class="handshake-line h-key">Upgrade: <span class="h-val">websocket</span></div>
+  <div class="handshake-line h-key">Sec-WebSocket-Key: <span class="h-val" id="ws-key">（连接时自动生成）</span></div>
+  <div class="handshake-line h-key">Sec-WebSocket-Version: <span class="h-val">13</span></div>
+  <br/>
+  <div class="handshake-line h-code">&#9660; HTTP/1.1 101 Switching Protocols</div>
+  <div class="handshake-line h-key">Upgrade: <span class="h-val">websocket</span></div>
+  <div class="handshake-line h-key">Connection: <span class="h-val">Upgrade</span></div>
+  <div class="handshake-line h-key">Sec-WebSocket-Accept: <span class="h-val" id="ws-accept">（服务器计算返回）</span></div>
+</div>
+
+<h2>4. 数据帧格式</h2>
+<div class="frame-visual">
+  <div id="frame-title" style="margin-bottom:12px;color:var(--accent2)">点击下方按钮查看不同类型帧的字节结构</div>
+  <div id="frame-bytes" style="display:flex;flex-wrap:wrap;gap:2px"></div>
+  <div class="frame-legend">
+    <div class="legend-item"><div class="legend-dot" style="background:var(--accent)"></div>FIN + RSV</div>
+    <div class="legend-item"><div class="legend-dot" style="background:var(--accent2)"></div>Opcode</div>
+    <div class="legend-item"><div class="legend-dot" style="background:var(--success)"></div>MASK</div>
+    <div class="legend-item"><div class="legend-dot" style="background:var(--error)"></div>Payload Length</div>
+    <div class="legend-item"><div class="legend-dot" style="background:#e91e63"></div>Masking Key</div>
+    <div class="legend-item"><div class="legend-dot" style="background:var(--surface2);border:1px solid var(--muted)"></div>Payload Data</div>
+  </div>
+</div>
+<div class="controls">
+  <button onclick="showFrame('text')">文本帧 (0x1)</button>
+  <button onclick="showFrame('close')">关闭帧 (0x8)</button>
+  <button onclick="showFrame('ping')">Ping 帧 (0x9)</button>
+  <button onclick="showFrame('binary')">二进制帧 (0x2)</button>
+</div>
+
+<h2>5. 心跳保活机制</h2>
+<div class="heartbeat-visual">
+  <div style="font-size:0.68rem;color:var(--muted)">客户端</div>
+  <div class="heartbeat-line"><div class="heartbeat-dot" id="hb-dot-c"></div></div>
+  <div class="hb-label" id="hb-label">idle</div>
+  <div class="heartbeat-line"><div class="heartbeat-dot" id="hb-dot-s"></div></div>
+  <div style="font-size:0.68rem;color:var(--muted)">服务器</div>
+</div>
+<div class="controls">
+  <button onclick="simulateHeartbeat()" class="primary">模拟一次心跳</button>
+  <button onclick="startAutoHeartbeat()" id="btn-auto-hb">启动自动心跳</button>
+</div>
+
+<h2>6. 常用关闭码</h2>
+<table>
+  <thead><tr><th>代码</th><th>名称</th><th>说明</th></tr></thead>
+  <tbody>
+    <tr><td class="code">1000</td><td>CLOSE_NORMAL</td><td>正常关闭，双方协商一致</td></tr>
+    <tr><td class="code">1001</td><td>CLOSE_GOING_AWAY</td><td>终端离开（如页面关闭）</td></tr>
+    <tr><td class="code">1002</td><td>CLOSE_PROTOCOL_ERROR</td><td>协议错误</td></tr>
+    <tr><td class="code">1006</td><td>CLOSE_ABNORMAL</td><td>异常关闭（网络中断、非正常断连）</td></tr>
+    <tr><td class="code">1009</td><td>CLOSE_TOO_LARGE</td><td>消息过大</td></tr>
+    <tr><td class="code">1011</td><td>CLOSE_UNEXPECTED_CONDITION</td><td>服务器内部错误</td></tr>
+  </tbody>
+</table>
+
+<h2>7. 重连策略（指数退避 + 抖动）</h2>
+<div id="reconnect-info" style="font-size:0.75rem;padding:12px;background:var(--surface);border-radius:8px;margin:12px 0;line-height:2">
+  <div>当前重连次数：<span id="reconnect-count" style="color:var(--accent)">0</span></div>
+  <div>下次重连延迟：<span id="reconnect-delay" style="color:var(--warn)">-</span></div>
+  <div style="margin-top:8px;color:var(--muted)">公式：delay = min(1000 × 2^n, 30000) × [0.5, 1.0] 随机因子</div>
+</div>
+<div class="controls">
+  <button onclick="showBackoffTable()" class="primary">查看退避表</button>
+</div>
+
+<h2>8. 连接日志</h2>
+<div class="log-area" id="log-area"></div>
+<div class="controls">
+  <button onclick="clearLog()" class="danger">清空日志</button>
+</div>
+
+<div class="modal-overlay" id="modal">
+  <div class="modal">
+    <h3 id="modal-title">详情</h3>
+    <div id="modal-content"></div>
+    <div style="margin-top:16px"><button onclick="closeModal()">关闭</button></div>
+  </div>
+</div>
+
+<script>
+const WS_URL = "ws://localhost:8080";
+const BASE_DELAY = 1000;
+const MAX_DELAY = 30000;
+const STEPS = ["tcp","upgrade","handshake","101","open"];
+
+let ws = null;
+let reconnectAttempts = 0;
+let hbTimer = null;
+let autoHbRunning = false;
+let animatingHb = false;
+
+function log(msg, type="info") {
+  const area = document.getElementById("log-area");
+  const t = new Date().toLocaleTimeString();
+  const el = document.createElement("div");
+  el.className = "log-entry";
+  el.innerHTML = `<span class="log-time">[${t}]</span> <span class="log-${type}">${msg}</span>`;
+  area.appendChild(el);
+  area.scrollTop = area.scrollHeight;
+}
+
+function clearLog() {
+  document.getElementById("log-area").innerHTML = "";
+  log("日志已清空", "warn");
+}
+
+function updateStatus(state) {
+  [0,1,2,3].forEach(i => document.getElementById("st"+i).classList.remove("active"));
+  if (state >= 0) document.getElementById("st"+state).classList.add("active");
+}
+
+function updateButtons(connected) {
+  document.getElementById("btn-connect").disabled = connected;
+  document.getElementById("btn-send").disabled = !connected;
+  document.getElementById("btn-hb").disabled = !connected;
+  document.getElementById("btn-close").disabled = !connected;
+}
+
+function advanceAllSteps() {
+  STEPS.forEach((s, i) => {
+    const el = document.getElementById("step-" + s);
+    el.classList.add("active");
+    setTimeout(() => el.classList.add("done"), i * 300);
+  });
+}
+
+function resetSteps() {
+  STEPS.forEach(s => document.getElementById("step-"+s).classList.remove("active","done"));
+}
+
+// ========== WebSocket ==========
+function connectWS() {
+  if (ws && ws.readyState < 2) { log("连接已存在", "warn"); return; }
+  log("正在连接 " + WS_URL + "...", "info");
+  updateStatus(0);
+  ws = new WebSocket(WS_URL);
+
+  ws.onopen = () => {
+    log("&#10003; 连接已建立 (OPEN)", "success");
+    updateStatus(1);
+    advanceAllSteps();
+    const key = genKey();
+    document.getElementById("ws-key").textContent = key + " (浏览器自动生成)";
+    document.getElementById("ws-accept").textContent = "s3pPLMBiTxaQ9kYGzzhZRbK+xOo= (服务器返回)";
+    updateButtons(true);
+    reconnectAttempts = 0;
+    updateReconnectInfo();
+    startAutoHeartbeat();
+  };
+
+  ws.onmessage = (event) => {
+    try {
+      const d = JSON.parse(event.data);
+      if (d.type === "ping") {
+        log("&#128229; 收到 Ping: ts=" + d.timestamp, "warn");
+        ws.send(JSON.stringify({ type: "pong", timestamp: Date.now() }));
+        log("&#128230; 已发送 Pong", "success");
+      } else if (d.type === "heartbeat" || d.type === "heartbeat_ack") {
+        log("&#10084;&#65039; 收到 " + d.type + ": ts=" + d.timestamp, "info");
+      } else {
+        log("&#128229; 收到: " + event.data, "info");
+      }
+    } catch {
+      log("&#128229; 收到文本: " + event.data, "info");
+    }
+  };
+
+  ws.onerror = (e) => log("&#10060; 错误: " + (e.type || "unknown"), "error");
+
+  ws.onclose = (e) => {
+    log("&#128222; 关闭: code=" + e.code + " reason=\"" + (e.reason||"") + "\" wasClean=" + e.wasClean, "error");
+    updateStatus(3);
+    updateButtons(false);
+    stopAutoHeartbeat();
+    resetSteps();
+    if (!e.wasClean && e.code !== 1000) scheduleReconnect();
+  };
+}
+
+function sendTestMsg() {
+  if (!ws || ws.readyState !== 1) { log("连接未就绪", "error"); return; }
+  const msg = "Hello " + Date.now();
+  ws.send(msg);
+  log("&#128230; 已发送: \"" + msg + "\"", "success");
+}
+
+function sendHeartbeat() {
+  if (!ws || ws.readyState !== 1) { log("连接未就绪", "error"); return; }
+  ws.send(JSON.stringify({ type: "heartbeat", timestamp: Date.now() }));
+  log("&#10084;&#65039; 已发送心跳", "info");
+}
+
+function closeWS() {
+  if (!ws) return;
+  log("正在关闭连接...", "warn");
+  ws.close(1000, "用户主动关闭");
+}
+
+function simulateDisconnect() {
+  if (!ws) { log("无连接可断开", "warn"); return; }
+  log("&#128308; 模拟断连（强制 close 1006）", "error");
+  ws.onclose = null;
+  ws.close(1006, "simulated disconnect");
+}
+
+// ========== 心跳 ==========
+function startAutoHeartbeat() {
+  if (autoHbRunning) return;
+  autoHbRunning = true;
+  document.getElementById("btn-auto-hb").textContent = "心跳运行中 (30s/次)...";
+  document.getElementById("btn-auto-hb").disabled = true;
+  hbTimer = setInterval(() => {
+    if (ws && ws.readyState === 1) {
+      ws.send(JSON.stringify({ type: "heartbeat", timestamp: Date.now() }));
+      log("&#10084;&#65039; [自动心跳] 已发送", "info");
+    }
+  }, 30000);
+}
+
+function stopAutoHeartbeat() {
+  if (hbTimer) { clearInterval(hbTimer); hbTimer = null; }
+  autoHbRunning = false;
+  const btn = document.getElementById("btn-auto-hb");
+  btn.textContent = "启动自动心跳";
+  btn.disabled = false;
+}
+
+function simulateHeartbeat() {
+  if (animatingHb) return;
+  animatingHb = true;
+  const dotC = document.getElementById("hb-dot-c");
+  const dotS = document.getElementById("hb-dot-s");
+  const label = document.getElementById("hb-label");
+
+  dotC.style.left = "0%";
+  dotS.style.left = "0%";
+  dotC.className = "heartbeat-dot";
+  dotS.className = "heartbeat-dot";
+
+  setTimeout(() => {
+    label.textContent = "ping &#8594;";
+    dotC.classList.add("ping");
+    dotC.style.left = "100%";
+    log("&#128230; Ping &#8594; (发送中)", "warn");
+  }, 80);
+
+  setTimeout(() => {
+    dotC.classList.remove("ping");
+    dotC.style.left = "0%";
+    dotS.classList.add("pong");
+    dotS.style.left = "100%";
+    label.textContent = "&#8592; pong";
+    log("&#128231; &#8592; Pong (收到响应)", "success");
+  }, 480);
+
+  setTimeout(() => {
+    dotS.classList.remove("pong");
+    dotS.style.left = "0%";
+    label.textContent = "idle";
+    animatingHb = false;
+  }, 880);
+}
+
+// ========== 重连 ==========
+function scheduleReconnect() {
+  reconnectAttempts++;
+  const backoff = Math.min(BASE_DELAY * Math.pow(2, reconnectAttempts - 1), MAX_DELAY);
+  const jitter = backoff * (0.5 + Math.random() * 0.5);
+  const delay = Math.round(jitter);
+  updateReconnectInfo();
+  log("&#128260; 重连 #" + reconnectAttempts + "，" + delay + "ms 后执行（退避+抖动）", "warn");
+  setTimeout(connectWS, delay);
+}
+
+function updateReconnectInfo() {
+  document.getElementById("reconnect-count").textContent = reconnectAttempts;
+  if (reconnectAttempts > 0) {
+    const b = Math.min(BASE_DELAY * Math.pow(2, reconnectAttempts - 1), MAX_DELAY);
+    document.getElementById("reconnect-delay").textContent = "&#8776; " + Math.round(b*0.75) + "&#8211;" + b + "ms";
+  }
+}
+
+// ========== 帧格式 ==========
+const FRAMES = {
+  text: {
+    title: "文本帧 Opcode=0x1（发送 \"Hi\"）",
+    bytes: [
+      {v:"1",c:"fin",t:"FIN=1"},{v:"0",c:"rsv",t:"RSV1"},{v:"0",c:"rsv",t:"RSV2"},{v:"0",c:"rsv",t:"RSV3"},
+      {v:"1",c:"opcode",t:"Opcode=1\n(Text)"},
+      {v:"1",c:"mask",t:"MASK=1\n(已掩码)"},
+      {v:"2",c:"len",t:"Length=2"},
+      {v:"0x37",c:"mask-key",t:"Key[0]"},{v:"0x2A",c:"mask-key",t:"Key[1]"},
+      {v:"0x61",c:"mask-key",t:"Key[2]"},{v:"0x14",c:"mask-key",t:"Key[3]"},
+      {v:"H^",c:"payload",t:"'H' ^ 0x37"},{v:"i!",c:"payload",t:"'i' ^ 0x2A"},
+    ]
+  },
+  close: {
+    title: "关闭帧 Opcode=0x8",
+    bytes: [
+      {v:"1",c:"fin",t:"FIN=1"},{v:"0",c:"rsv",t:"RSV"},
+      {v:"8",c:"opcode",t:"Opcode=8\n(Close)"},
+      {v:"0",c:"mask",t:"MASK=0"},
+      {v:"4",c:"len",t:"Length=4"},
+      {v:"0x03",c:"payload",t:"Code[0]\n0x03E8=1000"},{v:"0xE8",c:"payload",t:"Code[1]"},
+      {v:"OK",c:"payload",t:"Reason"},
+    ]
+  },
+  ping: {
+    title: "Ping 帧 Opcode=0x9",
+    bytes: [
+      {v:"1",c:"fin",t:"FIN=1"},{v:"0",c:"rsv",t:"RSV"},
+      {v:"9",c:"opcode",t:"Opcode=9\n(Ping)"},
+      {v:"0",c:"mask",t:"MASK=0"},
+      {v:"0",c:"len",t:"Length=0"},
+    ]
+  },
+  binary: {
+    title: "二进制帧 Opcode=0x2",
+    bytes: [
+      {v:"1",c:"fin",t:"FIN=1"},{v:"0",c:"rsv",t:"RSV"},
+      {v:"2",c:"opcode",t:"Opcode=2\n(Binary)"},
+      {v:"1",c:"mask",t:"MASK=1"},
+      {v:"5",c:"len",t:"Length=5"},
+      {v:"0x12",c:"mask-key",t:"Key[0]"},{v:"0x34",c:"mask-key",t:"Key[1]"},
+      {v:"0x56",c:"mask-key",t:"Key[2]"},{v:"0x78",c:"mask-key",t:"Key[3]"},
+      {v:"00",c:"payload",t:"Data[0]"},{v:"01",c:"payload",t:"Data[1]"},
+      {v:"02",c:"payload",t:"Data[2]"},{v:"03",c:"payload",t:"Data[3]"},
+      {v:"04",c:"payload",t:"Data[4]"},
+    ]
+  },
+};
+
+function showFrame(type) {
+  const f = FRAMES[type];
+  document.getElementById("frame-title").textContent = f.title;
+  document.getElementById("frame-bytes").innerHTML = f.bytes.map(b =>
+    `<div class="frame-byte ${b.c}" title="${b.t}">${b.v}</div>`
+  ).join("");
+  log("&#128202; 展示了 " + f.title, "info");
+}
+
+// ========== 弹窗 ==========
+function showBackoffTable() {
+  const rows = [];
+  for (let n = 1; n <= 8; n++) {
+    const base = Math.min(BASE_DELAY * Math.pow(2, n-1), MAX_DELAY);
+    const minD = Math.round(base * 0.5);
+    const maxD = base;
+    rows.push(`<tr><td class="code">${n}</td><td>${base >= MAX_DELAY ? "30s (上限)" : (base/1000)+"s"}</td><td>${minD}&#8211;${maxD}ms</td></tr>`);
+  }
+  document.getElementById("modal-title").textContent = "重连退避策略";
+  document.getElementById("modal-content").innerHTML = `
+    <p style="color:var(--muted);margin-bottom:12px">指数退避（Exponential Backoff）防止频繁重连造成服务端雪崩。随机抖动（Jitter）防止多客户端同时重连。</p>
+    <table><thead><tr><th>重试次数</th><th>基础延迟</th><th>实际范围（含抖动）</th></tr></thead><tbody>${rows.join("")}</tbody></table>
+    <pre style="margin-top:12px">// 抖动公式
+delay = baseDelay * (0.5 + Math.random() * 0.5)
+// 示例：base=1000 &#8594; [500ms, 1500ms]</pre>
+  `;
+  document.getElementById("modal").classList.add("show");
+}
+
+function closeModal() {
+  document.getElementById("modal").classList.remove("show");
+}
+
+document.getElementById("modal").addEventListener("click", (e) => {
+  if (e.target === document.getElementById("modal")) closeModal();
+});
+
+// ========== 工具 ==========
+function genKey() {
+  const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+  let k = "";
+  for (let i = 0; i < 16; i++) k += chars[Math.floor(Math.random() * chars.length)];
+  return btoa(k);
+}
+
+// 初始化
+log("&#128259; WebSocket 连接流程演示已就绪", "info");
+</script>
+</body>
+</html>


### PR DESCRIPTION
## 概述

整理了关于 CORS 多个 Access-Control-Allow-Origin 头部问题的技术文档和交互演示。

### 核心结论
- CORS 规范允许 Access-Control-Allow-Origin 包含多个值，但**没有任何浏览器支持此行为**
- 服务器返回多个 ACAO 头部 → 浏览器报错：Multiple CORS header Access-Control-Allow-Origin not allowed
- 正确做法：动态回显请求的 Origin（检查白名单后原样返回）

### 交付物

1. **docs/cors/multi-origin-analysis.md** (17KB)
   - 规范 vs 浏览器实现差异
   - 实际报错情况和错误信息
   - 正确的多域名 CORS 配置方法（动态 Origin 回显）
   - 常见踩坑场景（Nginx、Express、Flask 示例）
   - 参考资料

2. **examples/cors/multi-origin-demo.html** (47KB)
   - 4 个 Tab 导航：概述 / 规范 vs 实现 / 动态 Origin / 常见错误
   - SVG 流程图可视化
   - 可复制的代码示例（Node.js、Nginx、Python）
   - 交互式 Origin 检查模拟器

### 参考资料
- MDN: https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CORS/Errors/CORSMultipleAllowOriginNotAllowed
- PortSwigger: https://portswigger.net/web-security/cors/access-control-allow-origin